### PR TITLE
(FM-5142) fix private gem scooter failure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,10 +33,12 @@ group :system_tests do
   else
     gem 'beaker-rspec',  :require => false
   end
+  if ENV['GEM_SOURCE']
+    gem 'scooter', '~> 3.2', :require => false
+  end
   gem 'serverspec',    :require => false
   gem 'master_manipulator', '1.1.2',  :require => false
   gem 'beaker-puppet_install_helper', :require => false
-  gem 'scooter', '~>2.1'
 end
 
 if facterversion = ENV['FACTER_GEM_VERSION']


### PR DESCRIPTION
private gem scooter will fail if the test is running on CI as defined in https://confluence.puppetlabs.com/display/QA/Tips+and+Tricks+for+Module+Testing#TipsandTricksforModuleTesting-TestModuleWithAIX

gem 'scooter' need to be in the if statement to work around the issue
