### PR TITLE
(FM-5413) ERB markup translation from mustache templates

### DIFF
--- a/spec/acceptance/jdbc_spec.rb
+++ b/spec/acceptance/jdbc_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 require 'installer_constants'
 
 describe 'jdbc layer is setup and working' do
-  include_context "with a websphere base"
+  include_context "with a websphere class"
   include_context "with a websphere dmgr"
 
   before(:all) do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -29,7 +29,7 @@ def main
         WebSphereHelper.mount_QA_resources
         on host, puppet('module','install','puppet-archive')
         on host, puppet('module','install','puppetlabs-concat')
-        on host, puppet('module','install','puppetlabs-ibm_installation_manager')
+        on host, puppet('module','install', '--ignore-dependencies','puppetlabs-ibm_installation_manager')
         WebSphereHelper.install_ibm_manager(host) if host.host_hash[:roles].include?('master')
       end
     end

--- a/spec/support/context/with_websphere_class.rb
+++ b/spec/support/context/with_websphere_class.rb
@@ -1,0 +1,67 @@
+require 'spec_helper_acceptance'
+require 'installer_constants'
+
+shared_context 'with a websphere class' do
+  before(:all) do
+    @manifest = <<-MANIFEST
+    # Organizational log locations
+    file { [
+      '/opt/log',
+      '/opt/log/websphere',
+      '/opt/log/websphere/appserverlogs',
+      '/opt/log/websphere/applogs',
+      '/opt/log/websphere/wasmgmtlogs',
+    ]:
+      ensure => 'directory',
+      owner  => '#{WebSphereConstants.user}',
+      group  => '#{WebSphereConstants.group}',
+    }
+
+    # Base stuff for WebSphere.  Specify a common user/group and the base
+    # directory to where we want things to live.  Make sure the
+    # InstallationManager is managed before we do this.
+    class { '#{WebSphereConstants.class_name}':
+      user     => '#{WebSphereConstants.user}',
+      group    => '#{WebSphereConstants.group}',
+      base_dir => '#{WebSphereConstants.base_dir}',
+    }
+
+    #{WebSphereConstants.class_name}::instance { '#{WebSphereConstants.instance_name}':
+      target       => '#{WebSphereConstants.instance_base}',
+      package      => '#{WebSphereConstants.package_name}',
+      version      => '#{WebSphereConstants.package_version}',
+      profile_base => '#{WebSphereConstants.profile_base}',
+      repository   => "#{WebSphereConstants.repository}",
+      user         => '#{WebSphereConstants.user}',
+      group        => '#{WebSphereConstants.group}',
+    }
+
+    ibm_pkg { '#{FixpackConstants.name}':
+      ensure        => 'present',
+      package       => '#{WebSphereConstants.package_name}',
+      version       => '#{FixpackConstants.version}',
+      repository    => '#{FixpackConstants.repository}',
+      target        => '#{WebSphereConstants.instance_base}',
+      package_owner => '#{WebSphereConstants.user}',
+      package_group => '#{WebSphereConstants.group}',
+      require       => Websphere_application_server::Instance['#{WebSphereConstants.instance_name}'],
+    }
+
+    ibm_pkg { '#{JavaInstallerConstants.java7_name}':
+      ensure        => 'present',
+      package       => '#{JavaInstallerConstants.java7_package}',
+      version       => '#{JavaInstallerConstants.java7_version}',
+      repository    => "#{JavaInstallerConstants.java7_installer}/repository.config",
+      target        => '#{WebSphereConstants.instance_base}',
+      package_owner => '#{WebSphereConstants.user}',
+      package_group => '#{WebSphereConstants.group}',
+      require       => Ibm_pkg['#{FixpackConstants.name}'],
+    }
+    MANIFEST
+    @result = WebSphereHelper.agent_execute(@manifest)
+  end
+
+  it 'should run successfully' do
+    expect(@result.exit_code).to eq 2
+  end
+end

--- a/spec/support/context/with_websphere_dmgr.rb
+++ b/spec/support/context/with_websphere_dmgr.rb
@@ -4,7 +4,7 @@ require 'installer_constants'
 shared_context 'with a websphere dmgr' do
   before(:all) do
     hostname = WebSphereHelper.get_master
-    instance_manifest = <<-MANIFEST
+    @manifest = <<-MANIFEST
       ## Create a DMGR Profile
       #{WebSphereConstants.class_name}::profile::dmgr { '#{WebSphereConstants.dmgr_title}':
         instance_base => '#{WebSphereConstants.instance_base}',
@@ -24,7 +24,7 @@ shared_context 'with a websphere dmgr' do
         require      => Websphere_application_server::Profile::Dmgr['#{WebSphereConstants.dmgr_title}'],
       }
     MANIFEST
-    @result = WebSphereHelper.agent_execute(instance_manifest)
+    @result = WebSphereHelper.agent_execute(@manifest)
   end
 
   it 'should run successfully' do


### PR DESCRIPTION
I got generic ERB templates to work, but they did not suite WebSphere at the moment. There are dependencies in the module on the types which mean that the test manifests are long and specific.
