### PR TITLE
(maint) Fixes exec to allow exit code 2

### DIFF
--- a/manifests/profile/dmgr.pp
+++ b/manifests/profile/dmgr.pp
@@ -59,6 +59,7 @@ define websphere_application_server::profile::dmgr (
     cwd     => "${instance_base}/bin",
     user    => $user,
     timeout => 900,
+    returns => [0, 2]
   }
 
   # Ensure ownership of profile directory is correct


### PR DESCRIPTION
The managedprofiles.sh script on some platforms can return with
code '2', due to a warning about template deprecation.
