### PR TITLE
(maint) update tests to correct export cluster member

### DIFF
--- a/spec/acceptance/fixtures/websphere_appserver.erb
+++ b/spec/acceptance/fixtures/websphere_appserver.erb
@@ -9,9 +9,9 @@
   user          => '<%= WebSphereConstants.user %>',
   group         => '<%= WebSphereConstants.group %>',
 }
-->
-## Create and Add Cluster Member
-<%= WebSphereConstants.class_name %>::cluster::member { '<%= WebSphereConstants.appserver_title %>':
+
+## Export Cluster Member
+@@<%= WebSphereConstants.class_name %>::cluster::member { '<%= WebSphereConstants.appserver_title %>':
   ensure       => 'present',
   cluster      => '<%= WebSphereCluster.cluster_name %>',
   node_name    => '<%= agent_hostname %>',


### PR DESCRIPTION
Instead of creating the cluster member on the appserver catalog
itself, we need to export the member to puppetdb to allow the
dmgr to collect it as part of the managed cluster.