### PR TITLE
(maint) Update Rakefile for metadata-lint gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ task :metadata do
 end
 
 # Repeat the override of the metadata linting metadata_lint task.
-Rake::Task[:metadata_lint].clear
+Rake::Task[:metadata_lint].clear if Rake::Task.task_defined?('metadata_lint')
 desc "Check metadata is valid JSON"
 task :metadata_lint do
   sh "bundle exec metadata-json-lint metadata.json --no-strict-license"


### PR DESCRIPTION
Previously the rakefile would fail to compile any task if the metadata-lint
gem did not have its tasks loaded or the gem was missing.  This commit adds a
guard to the step which clears any previous defintion to only do this if the
task already exists.  Otherwise Rake would throw a Runtime Error.