### PR TITLE
(MODULES-5568) Add escaped quotes around the -databaseType parameter definition

### DIFF
--- a/lib/puppet/provider/websphere_jdbc_provider/wsadmin.rb
+++ b/lib/puppet/provider/websphere_jdbc_provider/wsadmin.rb
@@ -35,7 +35,7 @@ Puppet::Type.type(:websphere_jdbc_provider).provide(:wsadmin, :parent => Puppet:
   def params_string
     params_list =  "-name \"#{resource[:name]}\" "
     params_list << "-scope #{scope('mod')} "
-    params_list << "-databaseType #{resource[:dbtype]} "
+    params_list << "-databaseType \"#{resource[:dbtype]}\" "
     params_list << "-providerType \"#{resource[:providertype]}\" "
     params_list << "-implementationType \"#{resource[:implementation]}\" "
     params_list << "-description \"#{resource[:description]}\" " if resource[:description]


### PR DESCRIPTION
Websphere expects stings like "SQL Server" as a database type.  The space in this string is problematic in the current code.  Adding escaped quotes around the -databaseType parameter should resolve this.

This document refers to valid values for databaseType: https://www.ibm.com/support/knowledgecenter/en/SSAW57_8.0.0/com.ibm.websphere.nd.doc/info/ae/ae/rxml_7adminjdbc.html