### PR TITLE
(MODULES-4903) install websphere application server as a non-root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,8 +701,7 @@ A typical use case is specifying the user via the base class `websphere`. If thi
 
 ##### `manage_group`
 
-Boolean. Specifies whether this instance should manage the group specififed
-by the `group` parameter.
+Boolean. Specifies whether this instance should manage the group specififed by the `group` parameter.
 
 Defaults to `false`.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,3 +1,17 @@
+# @summary Manage setup for WebSphere installation and management
+#
+# @param base_dir
+#  The base directory containing IBM Software. Valid options: an absolute path to a directory.
+# @param user
+#  The user name that owns and executes the WebSphere installation. Valid options: a string containing a valid user name.
+# @param group
+#  The permissions group for the WebSphere installation. Valid options: a string containing a valid group name.
+# @param user_home
+#  Specifies the home directory for the specified user if `manage_user` is `true`. Valid options: an absolute path to a directory.
+# @param manage_user
+#  Specifies whether the class manages the user specified in `user`. Valid options: boolean.
+# @param manage_group
+#  Specifies whether the class manages the group specified in `group`. Valid options: boolean.
 #
 class websphere_application_server (
   $base_dir     = '/opt/IBM',

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -107,6 +107,7 @@ define websphere_application_server::instance (
     manage_ownership => true,
     package_owner    => $user,
     package_group    => $group,
+    user             => $user,
   }
 
   file { $_profile_base:

--- a/manifests/profile/dmgr.pp
+++ b/manifests/profile/dmgr.pp
@@ -50,7 +50,7 @@ define websphere_application_server::profile::dmgr (
   validate_string($_options)
 
   # Create the DMGR profile
-  # IBM's crap almost always exits 0, so we test that the profile directory
+  # IBM's stuff almost always exits 0, so we test that the profile directory
   # at leasts exists before saying success.
   exec { "was_profile_dmgr_${title}":
     command => "${instance_base}/bin/manageprofiles.sh ${_options} && test -d ${_profile_base}/${profile_name}",

--- a/spec/acceptance/add_cluster_members_spec.rb
+++ b/spec/acceptance/add_cluster_members_spec.rb
@@ -3,11 +3,16 @@ require 'installer_constants'
 
 describe 'add cluster members' do
   before(:all) do
+    runner = BeakerAgentRunner.new
+
     @dmgragent = WebSphereHelper.get_dmgr_host
     @appagent = WebSphereHelper.get_app_host
-    WebSphereInstance.install(@dmgragent)
-    WebSphereInstance.install(@appagent)
-    @dmgrmanifest = WebSphereDmgr.manifest(@dmgragent)
+    @webspheremanifest = WebSphereInstance.manifest
+    [@dmgragent, @appagent].each do |agent|
+      runner.execute_agent_on(agent, @webspheremanifest)
+    end
+
+    @dmgrmanifest = WebSphereDmgr.manifest(target_agent: @dmgragent)
     @appmanifest = WebSphereAppServer.manifest(@appagent, @dmgragent)
 
     @member1 = WebSphereHelper.get_fresh_node('redhat-7-x86_64')
@@ -15,7 +20,6 @@ describe 'add cluster members' do
     @member3 = WebSphereHelper.get_fresh_node('centos-6-x86_64')
 
     @execute_hash = { @dmgragent => @dmgrmanifest, @appagent => @appmanifest }
-    runner = BeakerAgentRunner.new
     @site_pp = runner.generate_site_pp(@execute_hash)
     runner.copy_site_pp(@site_pp)
     @dmgr_result = runner.execute_agent_on(@dmgragent)

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -2,54 +2,152 @@ require 'spec_helper_acceptance'
 require 'installer_constants'
 
 describe 'Verify the minimum install' do
-  context 'that the instance installs and is idempotent' do
-    before(:all) do
-      @agent = WebSphereHelper.get_dmgr_host
-      @manifest = WebSphereInstance.manifest
+  context 'as root user' do
+    let(:base_dir) { '/opt/IBM' }
+    let(:instance_base) { "#{base_dir}/#{WebSphereConstants.instance_name}/AppServer" }
+    let(:profile_base) { "#{instance_base}/profiles" }
+    let(:dmgr_profile) { "#{profile_base}/#{WebSphereConstants.dmgr_title}"}
 
-      runner = BeakerAgentRunner.new
-      @result = runner.execute_agent_on(@agent, @manifest)
-      @second_result = runner.execute_agent_on(@agent, @manifest)
+    context 'that the instance installs and is idempotent' do
+      before(:all) do
+        @agent = WebSphereHelper.get_dmgr_host
+        @manifest = WebSphereInstance.manifest
+
+        runner = BeakerAgentRunner.new
+        @result = runner.execute_agent_on(@agent, @manifest)
+        @second_result = runner.execute_agent_on(@agent, @manifest)
+      end
+
+      it 'class should run successfully' do
+        expect([0, 2]).to include(@result.exit_code)
+      end
+
+      it 'class should be idempotent' do
+        expect(@second_result.exit_code).to eq 0
+      end
+
+      it 'shall be installed to the instance directory' do
+        rc = WebSphereHelper.remote_dir_exists(@agent, instance_base)
+        expect(rc).to eq 0
+      end
     end
+    context 'that the dmgr installs and is idempotent' do
+      before(:all) do
+        @agent = WebSphereHelper.get_dmgr_host
+        fail "@agent MUST be set for the websphere class to install" unless @agent.hostname
+        @manifest = WebSphereDmgr.manifest(target_agent: @agent)
 
-    it 'class should run successfully' do
-      expect([0, 2]).to include(@result.exit_code)
-    end
+        runner = BeakerAgentRunner.new
+        @result = runner.execute_agent_on(@agent, @manifest)
+        @second_result = runner.execute_agent_on(@agent, @manifest)
+      end
 
-    it 'class should be idempotent' do
-      expect(@second_result.exit_code).to eq 0
-    end
+      it 'dmgr should run successfully' do
+        expect([0, 2]).to include(@result.exit_code)
+      end
 
-    it 'shall be installed to the instance directory' do
-      rc = WebSphereHelper.remote_dir_exists(@agent, WebSphereConstants.base_dir + '/' + WebSphereConstants.instance_name + '/AppServer')
-      expect(rc).to eq 0
+      it 'dmgr is idempotent' do
+        expect(@second_result.exit_code).to eq 0
+      end
+
+      it 'shall be installed on the agent' do
+        rc = WebSphereHelper.remote_dir_exists(@agent, @profile_base)
+        expect(rc).to eq 0
+      end
+
+      it "profile binaries are present" do
+        ["#{dmgr_profile}/bin/startServer.sh",
+        "#{dmgr_profile}/bin/stopServer.sh",
+        "#{dmgr_profile}/bin/manageprofiles.sh"].each do |bin|
+          expect(WebSphereHelper.remote_file_exists(@agent, bin)).to eq 0
+        end
+      end
+
+      after(:all) do
+        manifest = WebSphereHelper.stop_server(server_name: 'dmgr',
+                                               user: 'root',
+                                               profile_base: '/opt/IBM/WebSphere85/AppServer/profiles',
+                                               profile_name: 'PROFILE_DMGR_02')
+        runner = BeakerAgentRunner.new
+        runner.execute_agent_on(@agent, manifest)
+      end
+
+      it_behaves_like 'a running dmgr', "/opt/IBM/WebSphere85/AppServer/profiles", WebSphereConstants.dmgr_title
     end
   end
-  context 'that the dmgr installs and is idempotent' do
-    before(:all) do
-      @agent = WebSphereHelper.get_dmgr_host
-      fail "@agent MUST be set for the websphere class to install" unless @agent.hostname
 
-      @manifest = WebSphereDmgr.manifest(@agent)
+  context 'as nonadministrator' do
+    let(:base_dir) { '/home/webadmin/IBM' }
+    let(:instance_base) { "#{base_dir}/#{WebSphereConstants.instance_name}/AppServer" }
+    let(:profile_base) { "#{instance_base}/profiles" }
+    let(:dmgr_profile) { "#{profile_base}/#{WebSphereConstants.dmgr_title}"}
 
-      runner = BeakerAgentRunner.new
-      @result = runner.execute_agent_on(@agent, @manifest)
-      @second_result = runner.execute_agent_on(@agent, @manifest)
+    context 'that the instance installs and is idempotent' do
+      before(:all) do
+        @agent = WebSphereHelper.get_dmgr_host
+        @manifest = WebSphereInstance.manifest(base_dir: '/home/webadmin/IBM' )
+
+        runner = BeakerAgentRunner.new
+        @result = runner.execute_agent_on(@agent, @manifest)
+        @second_result = runner.execute_agent_on(@agent, @manifest)
+      end
+
+      it 'class should run successfully' do
+        expect([0, 2]).to include(@result.exit_code)
+      end
+
+      it 'class should be idempotent' do
+        expect(@second_result.exit_code).to eq 0
+      end
+
+      it 'shall be installed to the instance directory' do
+        rc = WebSphereHelper.remote_dir_exists(@agent, instance_base)
+        expect(rc).to eq 0
+      end
     end
+    context 'that the dmgr installs and is idempotent' do
+      before(:all) do
+        @agent = WebSphereHelper.get_dmgr_host
+        fail "@agent MUST be set for the websphere class to install" unless @agent.hostname
+        @manifest = WebSphereDmgr.manifest(target_agent: @agent,
+                                           base_dir: '/home/webadmin/IBM')
 
-    it 'dmgr should run successfully' do
-      expect([0, 2]).to include(@result.exit_code)
+        runner = BeakerAgentRunner.new
+        @result = runner.execute_agent_on(@agent, @manifest)
+        @second_result = runner.execute_agent_on(@agent, @manifest)
+      end
+
+      it 'dmgr should run successfully' do
+        expect([0, 2]).to include(@result.exit_code)
+      end
+
+      it 'dmgr is idempotent' do
+        expect(@second_result.exit_code).to eq 0
+      end
+
+      it 'shall be installed on the agent' do
+        rc = WebSphereHelper.remote_dir_exists(@agent, @profile_base)
+        expect(rc).to eq 0
+      end
+
+      it "profile binaries are present" do
+        ["#{dmgr_profile}/bin/startServer.sh",
+          "#{dmgr_profile}/bin/stopServer.sh",
+          "#{dmgr_profile}/bin/manageprofiles.sh"].each do |bin|
+          expect(WebSphereHelper.remote_file_exists(@agent, bin)).to eq 0
+        end
+      end
+
+      it_behaves_like 'a running dmgr', "/home/webadmin/IBM/WebSphere85/AppServer/profiles", WebSphereConstants.dmgr_title
+
+      after(:all) do
+        manifest = WebSphereHelper.stop_server(server_name: 'dmgr',
+                                               user: 'webadmin',
+                                               profile_base: '/home/webadmin/IBM/WebSphere85/AppServer/profiles',
+                                               profile_name: 'PROFILE_DMGR_02')
+        runner = BeakerAgentRunner.new
+        runner.execute_agent_on(@agent, manifest)
+      end
     end
-
-    it 'dmgr is idempotent' do
-      expect(@second_result.exit_code).to eq 0
-    end
-
-    it 'shall be installed on the agent' do
-      rc = WebSphereHelper.remote_dir_exists(@agent, WebSphereConstants.profile_base)
-      expect(rc).to eq 0
-    end
-
-    it_behaves_like 'a running dmgr'
   end
 end

--- a/spec/acceptance/dmgr_spec.rb
+++ b/spec/acceptance/dmgr_spec.rb
@@ -13,7 +13,7 @@ describe 'Install the websphere dmgr' do
       expect(WebSphereHelper.remote_file_exists(@agent, WebSphereConstants.ws_admin))
   end
 
-  it_behaves_like 'a running dmgr'
+  it_behaves_like 'a running dmgr', WebSphereConstants.profile_base, WebSphereConstants.dmgr_title
 
   context 'should stop the dmgr service' do
     before(:all) do
@@ -34,7 +34,7 @@ describe 'Install the websphere dmgr' do
     end
 
     it_behaves_like 'an idempotent resource'
-    it_behaves_like 'a stopped dmgr'
+    it_behaves_like 'a stopped dmgr', WebSphereConstants.profile_base, WebSphereConstants.dmgr_title
   end
 
   context 'should start the dmgr service' do
@@ -56,6 +56,6 @@ describe 'Install the websphere dmgr' do
     end
 
     it_behaves_like 'an idempotent resource'
-    it_behaves_like 'a running dmgr'
+    it_behaves_like 'a running dmgr', WebSphereConstants.profile_base, WebSphereConstants.dmgr_title
   end
 end

--- a/spec/acceptance/fixtures/websphere_class.erb
+++ b/spec/acceptance/fixtures/websphere_class.erb
@@ -1,4 +1,3 @@
-
 # Inputs : instance_name, fixpack_name, instance_base, profile_base, java7_name
 # The rest are loaded from the WebSphereConstants.
 
@@ -8,19 +7,25 @@ file { [
   '/opt/log/websphere/appserverlogs',
   '/opt/log/websphere/applogs',
   '/opt/log/websphere/wasmgmtlogs',
+  '/home/webadmin/log',
+  '/home/webadmin/log/websphere',
+  '/home/webadmin/log/websphere/appserverlogs',
+  '/home/webadmin/log/websphere/applogs',
+  '/home/webadmin/log/websphere/wasmgmtlogs',
 ]:
   ensure => 'directory',
-  owner  => '<%= WebSphereConstants.user %>',
-  group  => '<%= WebSphereConstants.group %>',
+  owner  => '<%= user %>',
+  group  => '<%= group %>',
 }
-
 # Base stuff for WebSphere.  Specify a common user/group and the base
 # directory to where we want things to live.  Make sure the
 # InstallationManager is managed before we do this.
 class { '<%= WebSphereConstants.class_name %>':
-  user     => '<%= WebSphereConstants.user %>',
-  group    => '<%= WebSphereConstants.group %>',
-  base_dir => '<%= WebSphereConstants.base_dir %>',
+  user     => '<%= user %>',
+  group    => '<%= group %>',
+  base_dir => '<%= base_dir %>',
+  manage_user => false,
+  manage_group => false,
 }
 
 <%= WebSphereConstants.class_name %>::instance { '<%= instance_name %>':
@@ -29,8 +34,8 @@ class { '<%= WebSphereConstants.class_name %>':
   version      => '<%= WebSphereConstants.package_version %>',
   profile_base => '<%= profile_base %>',
   repository   => "<%= WebSphereConstants.repository %>",
-  user         => '<%= WebSphereConstants.user %>',
-  group        => '<%= WebSphereConstants.group %>',
+  user         => '<%= user %>',
+  group        => '<%= group %>',
 }
 
 ibm_pkg { '<%= fixpack_name %>':
@@ -39,8 +44,9 @@ ibm_pkg { '<%= fixpack_name %>':
   version       => '<%= FixpackConstants.version %>',
   repository    => '<%= FixpackConstants.repository %>',
   target        => '<%= instance_base %>',
-  package_owner => '<%= WebSphereConstants.user %>',
-  package_group => '<%= WebSphereConstants.group %>',
+  package_owner => '<%= user %>',
+  package_group => '<%= group %>',
+  user          => '<%= user %>',
   require       => Websphere_application_server::Instance['<%= instance_name %>'],
 }
 
@@ -50,7 +56,8 @@ ibm_pkg { '<%= java7_name %>':
   version       => '<%= JavaInstallerConstants.java7_version %>',
   repository    => "<%= JavaInstallerConstants.java7_installer %>/repository.config",
   target        => '<%= instance_base %>',
-  package_owner => '<%= WebSphereConstants.user %>',
-  package_group => '<%= WebSphereConstants.group %>',
+  package_owner => '<%= user %>',
+  package_group => '<%= group %>',
+  user          => '<%= user %>',
   require       => Ibm_pkg['<%= fixpack_name %>'],
 }

--- a/spec/acceptance/fixtures/websphere_dmgr.erb
+++ b/spec/acceptance/fixtures/websphere_dmgr.erb
@@ -1,17 +1,17 @@
 ## Create a DMGR Profile
 <%= WebSphereConstants.class_name %>::profile::dmgr { '<%= WebSphereConstants.dmgr_title %>':
-  instance_base => '<%= WebSphereConstants.instance_base %>',
-  profile_base  => '<%= JDBCProviderConstants.profile_base %>',
+instance_base => '<%= instance_base %>',
+  profile_base  => '<%= profile_base %>',
   cell          => '<%= JDBCProviderConstants.cell %>',
   node_name     => '<%= agent_hostname %>',
-  user          => '<%= WebSphereConstants.user %>',
-  group         => '<%= WebSphereConstants.group %>',
+  user          => '<%= user %>',
+  group         => '<%= group %>',
 }
 ->
 ## Create a cluster
 <%= WebSphereConstants.class_name %>::cluster { '<%= WebSphereCluster.cluster_name %>':
-  profile_base => '<%= WebSphereConstants.profile_base %>',
+  profile_base => '<%= profile_base %>',
   dmgr_profile => '<%= WebSphereConstants.dmgr_title %>',
   cell         => '<%= WebSphereConstants.cell %>',
-  user         => '<%= WebSphereConstants.user %>',
+  user         => '<%= user %>',
 }

--- a/spec/acceptance/fixtures/websphere_ihs.erb
+++ b/spec/acceptance/fixtures/websphere_ihs.erb
@@ -1,11 +1,13 @@
 class { 'websphere_application_server':
-  user     => "<%= WebSphereConstants.user %>",
-  group    => "<%= WebSphereConstants.group %>",
-  base_dir => "<%= WebSphereConstants.base_dir %>",
+  user         => "<%= user %>",
+  group        => "<%= group %>",
+  base_dir     => "<%= base_dir %>",
+  manage_user  => false,
+  manage_group => false,
 }
 
 websphere_application_server::ihs::instance { '<%= IhsInstance.ihs_target %>':
-  target           => "<%= WebSphereConstants.base_dir %>/<%= IhsInstance.ihs_target %>",
+  target           => "<%= base_dir %>/<%= IhsInstance.ihs_target %>",
   package          => "<%= IhsInstance.package_ihs %>",
   version          => "<%= WebSphereConstants.package_version %>",
   repository       => '/opt/QA_resources/ibm_websphere/ihs_ilan/repository.config',
@@ -20,7 +22,7 @@ websphere_application_server::ihs::instance { '<%= IhsInstance.ihs_target %>':
 
 ibm_pkg { 'Plugins':
   ensure     => 'present',
-  target     => "<%= WebSphereConstants.base_dir %>/Plugins",
+  target     => "<%= base_dir %>/Plugins",
   repository => '/opt/QA_resources/ibm_websphere/plg_ilan/repository.config',
   package    => "<%= IhsInstance.package_plugin %>",
   version    => "<%= WebSphereConstants.package_version %>",
@@ -29,12 +31,12 @@ ibm_pkg { 'Plugins':
 
 websphere_application_server::ihs::server { 'ihs_server':
   status      => '<%= ihs_status %>',
-  target      => "<%= WebSphereConstants.base_dir %>/<%= IhsInstance.ihs_target %>",
+  target      => "<%= base_dir %>/<%= IhsInstance.ihs_target %>",
   log_dir     => '/opt/log/websphere/httpserver',
-  plugin_base => "<%= WebSphereConstants.base_dir %>/Plugins",
+  plugin_base => "<%= base_dir %>/Plugins",
   dmgr_host    => <%= IhsInstance.dmgr_host %>,
   cell        => "<%= WebSphereConstants.cell %>",
-  httpd_config => "<%= WebSphereConstants.base_dir %>/<%= IhsInstance.ihs_target %>/conf/httpd_test.conf",
+  httpd_config => "<%= base_dir %>/<%= IhsInstance.ihs_target %>/conf/httpd_test.conf",
   access_log  => '/opt/log/websphere/httpserver/access_log',
   error_log   => '/opt/log/websphere/httpserver/error_log',
   listen_port => "<%= listen_port %>",

--- a/spec/acceptance/fixtures/websphere_stop_server.erb
+++ b/spec/acceptance/fixtures/websphere_stop_server.erb
@@ -1,0 +1,8 @@
+exec { 'stop server':
+  user => 'root',
+<% if user == 'root' -%>
+  command => "<%= profile_base %>/<%= profile_name %>/bin/stopServer.sh <%= server_name %> -profileName <%= profile_name %>",
+<% else -%>
+  command => "/bin/su - <%= user %> -c '<%= profile_base %>/<%= profile_name %>/bin/stopServer.sh <%= server_name %> -profileName <%= profile_name %> '",
+<% end -%>
+}

--- a/spec/acceptance/ihs_spec.rb
+++ b/spec/acceptance/ihs_spec.rb
@@ -4,14 +4,20 @@ require 'installer_constants'
 describe 'IHS instance' do
   before(:all) do
     @agent = WebSphereHelper.get_ihs_server
-    WebSphereInstance.install(@agent)
-    WebSphereDmgr.install(@agent)
+    @ws_manifest = WebSphereInstance.manifest(user: 'webadmin',
+                                              group: 'webadmins')
+    @dmgr_manifest = WebSphereDmgr.manifest(target_agent: @agent)
     @ihs_host     = @agent.hostname
     @listen_port  = 10080
 
-    @manifest = WebSphereIhs.manifest(@agent, @listen_port)
+    @ihs_manifest = WebSphereIhs.manifest(user: 'webadmin',
+                                          group: 'webadmins',
+                                          target_agent: @agent,
+                                          listen_port: @listen_port)
     runner = BeakerAgentRunner.new
-    @result = runner.execute_agent_on(@agent, @manifest)
+    runner.execute_agent_on(@agent, @ws_manifest)
+    runner.execute_agent_on(@agent, @dmgr_manifest)
+    @result = runner.execute_agent_on(@agent, @ihs_manifest)
   end
 
   it 'should run without errors' do
@@ -54,9 +60,13 @@ describe 'IHS instance' do
       @ihs_host     = @agent.hostname
       @listen_port  = 10080
 
-      @manifest = WebSphereIhs.manifest(@agent, @listen_port, status='stopped')
+      @ihs_manifest = WebSphereIhs.manifest(user: 'webadmin',
+                                            group: 'webadmins',
+                                            target_agent: @agent,
+                                            listen_port: @listen_port,
+                                            status: 'stopped')
       runner = BeakerAgentRunner.new
-      @result = runner.execute_agent_on(@agent, @manifest)
+      @result = runner.execute_agent_on(@agent, @ihs_manifest)
     end
 
     it 'should run without errors' do
@@ -71,7 +81,7 @@ describe 'IHS instance' do
 
     it 'should run a second time without changes' do
       runner = BeakerAgentRunner.new
-      second_result = runner.execute_agent_on(@agent, @manifest)
+      second_result = runner.execute_agent_on(@agent, @ihs_manifest)
       expect(second_result.exit_code).to eq 2
     end
   end

--- a/spec/acceptance/jdbc_spec.rb
+++ b/spec/acceptance/jdbc_spec.rb
@@ -4,8 +4,11 @@ require 'installer_constants'
 describe 'jdbc layer is setup and working' do
   before(:all) do
     @agent = WebSphereHelper.get_ihs_server
-    WebSphereInstance.install(@agent)
-    WebSphereDmgr.install(@agent)
+    @was_manifest = WebSphereInstance.manifest(user: 'webadmin',
+                                               group: 'webadmins')
+    @dmgr_manifest = WebSphereDmgr.manifest(target_agent: @agent,
+                                            user: 'webadmin',
+                                            group: 'webadmins')
     @hostname = @agent.hostname
 
     @manifest = <<-MANIFEST
@@ -44,6 +47,8 @@ describe 'jdbc layer is setup and working' do
 
     MANIFEST
     runner = BeakerAgentRunner.new
+    runner.execute_agent_on(@agent, @was_manifest)
+    runner.execute_agent_on(@agent, @dmgr_manifest)
     @result = runner.execute_agent_on(@agent, @manifest)
   end
 

--- a/spec/installer_constants.rb
+++ b/spec/installer_constants.rb
@@ -1,4 +1,4 @@
-#CONSTANTS
+
 module HelperConstants
   @unsupported_platforms    = ['Suse','windows','AIX','Solaris']
   @websphere_source_dir     = '/opt/sources/ibm_websphere'
@@ -12,7 +12,9 @@ end
 module WebSphereConstants
   @base_dir               = '/opt/IBM'
   @user                   = 'webadmin'
+  @user_home              = '/'
   @group                  = 'webadmins'
+  @installation_mode      = 'administrator'
   @instance_base          = @base_dir + '/WebSphere85/AppServer'
   @profile_base           = @instance_base + '/profiles'
 
@@ -43,7 +45,7 @@ module WebSphereConstants
   class << self
     attr_reader :base_dir, :instance_base, :profile_base, :was_installer, :instance_name,
                 :package_name,:package_version, :update_package_version, :repository, :class_name, :fixpack_installer,
-                :java_installer, :java_package, :java_version, :cell, :appserver_title,
+                :java_installer, :java_package, :java_version, :cell, :appserver_title, :user_home, :installation_mode,
                 :dmgr_title, :cluster_title, :cluster_member, :user, :group, :dmgr_status, :ws_admin
   end
 end

--- a/spec/support/examples/operational_dmgr.rb
+++ b/spec/support/examples/operational_dmgr.rb
@@ -1,8 +1,8 @@
 
-shared_examples 'a running dmgr' do
+shared_examples 'a running dmgr' do |profile_base, dmgr_title|
   before(:all) do
-    @dmgr_result     = on(@agent, "#{WebSphereConstants.dmgr_status} -all -profileName #{WebSphereConstants.dmgr_title} |  grep 'The Deployment Manager'", :acceptable_exit_codes => [0,1])
-    @ws_admin_result = on(@agent, "#{WebSphereConstants.ws_admin} -lang jython -c \"AdminConfig.getid('/ServerCluster: #{WebSphereConstants.cluster_member}/')\"", :acceptable_exit_codes => [0,1,103])
+    @dmgr_result     = on(@agent, "#{profile_base}/#{dmgr_title}/bin/serverStatus.sh -all -profileName #{dmgr_title} |  grep 'The Deployment Manager'", :acceptable_exit_codes => [0,1])
+    @ws_admin_result = on(@agent, "#{profile_base}/#{dmgr_title}/bin/wsadmin.sh -lang jython -c \"AdminConfig.getid('/ServerCluster: #{WebSphereConstants.cluster_member}/')\"", :acceptable_exit_codes => [0,1,103])
   end
 
   it 'should be contactable' do
@@ -16,10 +16,10 @@ shared_examples 'a running dmgr' do
   end
 end
 
-shared_examples 'a stopped dmgr' do
+shared_examples 'a stopped dmgr' do |profile_base, dmgr_title|
   before(:all) do
-    @dmgr_result     = on(@agent, "#{WebSphereConstants.dmgr_status} -all -profileName #{WebSphereConstants.dmgr_title} |  grep 'The Deployment Manager'", :acceptable_exit_codes => [0,1])
-    @ws_admin_result = on(@agent, "#{WebSphereConstants.ws_admin} -lang jython -c \"AdminConfig.getid('/ServerCluster: #{WebSphereConstants.cluster_member}/')\"", :acceptable_exit_codes => [0,1,103])
+    @dmgr_result     = on(@agent, "#{profile_base}/#{dmgr_title}/bin/serverStatus.sh -all -profileName #{WebSphereConstants.dmgr_title} |  grep 'The Deployment Manager'", :acceptable_exit_codes => [0,1])
+    @ws_admin_result = on(@agent, "#{profile_base}/#{dmgr_title}/bin/wsadmin.sh -lang jython -c \"AdminConfig.getid('/ServerCluster: #{WebSphereConstants.cluster_member}/')\"", :acceptable_exit_codes => [0,1,103])
   end
 
   it 'should not be contactable' do


### PR DESCRIPTION
This PR is action-packed. The big idea here is passing $user through to ibm_pkg resources so that $user owns the installation, root user or not. This required mostly a lot of test refactoring.