### PR TITLE
pdksync - (MODULES-7705) - Bumping stdlib dependency from < 5.0.0 to < 6.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/ibm_installation_manager",


### PR DESCRIPTION
(MODULES-7705) - Bumping stdlib dependency from < 5.0.0 to < 6.0.0
pdk version: `1.7.0` 
