### PR TITLE
(maint) - Bumping concat version dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.1.0 < 5.0.0"
+      "version_requirement": ">= 1.1.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
As concat is now sitting on 5.1.0 this version needs bumped to obtain bugfixes and the latest release of concat.