### PR TITLE
Add support for BASE installations

### DIFF
--- a/manifests/profile/service.pp
+++ b/manifests/profile/service.pp
@@ -90,13 +90,17 @@ define websphere_application_server::profile::service (
   }
 
   if ! $status {
-    if $type == 'dmgr' {
-      $_status = "/bin/su - ${user} -c '${profile_base}/${profile_name}/bin/serverStatus.sh dmgr ${_auth_string} -profileName ${profile_name} | grep -q STARTED'"
-    } else {
-      $_status = "/bin/su - ${user} -c '${profile_base}/${profile_name}/bin/serverStatus.sh nodeagent -profileName ${profile_name} ${_auth_string}| grep -q STARTED'"
+    case $type {
+      'dmgr': {
+        $_status = "/bin/su - ${user} -c '${profile_base}/${profile_name}/bin/serverStatus.sh dmgr ${_auth_string} -profileName ${profile_name} | grep -q STARTED'"
+      }
+      'adminagent': {
+        $_status = "/bin/su - ${user} -c '${profile_base}/${profile_name}/bin/serverStatus.sh adminagent| grep -q STARTED'"
+      }
+      default: {
+        $_status = "/bin/su - ${user} -c '${profile_base}/${profile_name}/bin/serverStatus.sh nodeagent -profileName ${profile_name} ${_auth_string}| grep -q STARTED'"
+      }
     }
-  } else {
-    $_status = $status
   }
 
   if ! $start {

--- a/manifests/profile/service.pp
+++ b/manifests/profile/service.pp
@@ -72,7 +72,7 @@ define websphere_application_server::profile::service (
 
   ## Really, we can create more profile types than this, but this is all we
   ## support right now.
-  validate_re($type, '(dmgr|app|appserver|node)')
+  validate_re($type, '(dmgr|app|appserver|node|adminagent)')
   validate_absolute_path($profile_base)
   validate_string($profile_name)
   validate_string($user)
@@ -100,20 +100,32 @@ define websphere_application_server::profile::service (
   }
 
   if ! $start {
-    if $type == 'dmgr' {
-      $_start = "/bin/su - ${user} -c '${profile_base}/${profile_name}/bin/startManager.sh -profileName ${profile_name} ${_auth_string}'"
-    } else {
-      $_start = "/bin/su - ${user} -c '${profile_base}/${profile_name}/bin/startNode.sh ${_auth_string}'"
+    case $type {
+      'dmgr': {
+        $_start = "/bin/su - ${user} -c '${profile_base}/${profile_name}/bin/startManager.sh -profileName ${profile_name} ${_auth_string}'"
+      }
+      'adminagent':{
+        $_start = "/bin/su - ${user} -c '${profile_base}/${profile_name}/bin/startServer.sh adminagent'"
+      }
+      default:{
+        $_start = "/bin/su - ${user} -c '${profile_base}/${profile_name}/bin/startNode.sh ${_auth_string}'"
+      }
     }
   } else {
     $_start = $start
   }
 
   if ! $stop {
-    if $type == 'dmgr' {
-      $_stop = "/bin/su - ${user} -c '${profile_base}/${profile_name}/bin/stopManager.sh -profileName ${profile_name} ${_auth_string}'"
-    } else {
-      $_stop = "/bin/su - ${user} -c '${profile_base}/${profile_name}/bin/stopNode.sh ${_auth_string}'"
+    case $type {
+      'dmgr': {
+        $_stop = "/bin/su - ${user} -c '${profile_base}/${profile_name}/bin/stopManager.sh -profileName ${profile_name} ${_auth_string}'"
+      }
+      'adminagent':{
+        $_stop = "/bin/su - ${user} -c '${profile_base}/${profile_name}/bin/stopServer.sh adminagent'"
+      }
+      default:{
+        $_stop = "/bin/su - ${user} -c '${profile_base}/${profile_name}/bin/stopNode.sh ${_auth_string}'"
+      }
     }
   } else {
     $_stop = $stop


### PR DESCRIPTION
Currently this module assumes that the WebSphere installation is of type ND. If a BASE installation is used and a `websphere_application_server::profile::appserver` is defined this module tries to use the wrong start/stop scripts. On inspection of the called service manifest it seems that there was some consideration for other types of service but it defaults to the ND type of service.

This PR extends the knowledge of the appserver by specifying the instance type. If `instance_is_nd` (which defaults to 'true' to preserve previous behavior) is set to 'false' the management of DMGR/federation is skipped . Additionally the `websphere_application_server::profile::service` is called with `type =>'adminagent'`. This enables the selection of the correct start/stop scripts.