### PR TITLE
Adding resources, improving existing resources

### DIFF
--- a/lib/puppet/provider/websphere_jdbc_datasource_custom_property/wsadmin.rb
+++ b/lib/puppet/provider/websphere_jdbc_datasource_custom_property/wsadmin.rb
@@ -1,0 +1,152 @@
+require_relative '../websphere_helper'
+#
+Puppet::Type.type(:websphere_jdbc_datasource_custom_property).provide(:wsadmin, parent: Puppet::Provider::Websphere_Helper) do
+  # @private
+  # Helper method
+  def scope(what)
+    file = "#{resource[:profile_base]}/#{resource[:dmgr_profile]}"
+    case resource[:scope]
+    when 'cell'
+      query = '/Cell:' + "#{resource[:cell]}/JDBCProvider:#{resource[:jdbc_provider]}/DataSource:#{resource[:jdbc_datasource]}/"
+      file += "/config/cells/#{resource[:cell]}/resources.xml"
+    when 'node'
+      query = '/Cell:' + "#{resource[:cell]}/" + 'Node:' + "#{resource[:node_name]}/JDBCProvider:#{resource[:jdbc_provider]}/DataSource:#{resource[:jdbc_datasource]}/"
+      file += "/config/cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/resources.xml"
+    when 'server'
+      # rubocop:disable Metrics/LineLength
+      query = '/Cell:' + "#{resource[:cell]}/" + 'Node:' + "#{resource[:node_name]}/" + 'Server:' + "#{resource[:server]}/JDBCProvider:#{resource[:jdbc_provider]}/DataSource:#{resource[:jdbc_datasource]}/"
+      # rubocop:enable Metrics/LineLength
+      file += "/config/cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/servers/#{resource[:server]}/resources.xml"
+    when 'cluster'
+      query = '/Cell:' + "#{resource[:cell]}/" + 'ServerCluster:' + "#{resource[:cluster]}/JDBCProvider:#{resource[:jdbc_provider]}/DataSource:#{resource[:jdbc_datasource]}/"
+      file += "/config/cells/#{resource[:cell]}/clusters/#{resource[:cluster]}/resources.xml"
+    else
+      raise Puppet::Error, "Unknown scope: #{resource[:scope]}"
+    end
+
+    case what
+    when 'query'
+      query
+    when 'file'
+      file
+    else
+      debug 'Invalid scope request'
+    end
+  end
+
+  # @private
+  # Helper method
+  def resource_xpath
+    "//resources.jdbc:JDBCProvider[@name='#{resource[:jdbc_provider]}']/factories[@name='#{resource[:jdbc_datasource]}']/propertySet/resourceProperties[@name='#{resource[:name]}']"
+  end
+
+  # @private
+  # Helper method
+  def get_property_value(prop)
+    xml_file = scope('file')
+    doc = REXML::Document.new(File.open(xml_file))
+    path = REXML::XPath.first(doc, resource_xpath)
+    value = REXML::XPath.first(path, "@#{prop}").to_s if path
+
+    debug "Exists? Found match for #{resource[:name]}. #{prop} is: #{value}" if value
+    value
+  end
+
+  def exists?
+    xml_file = scope('file')
+
+    unless File.exist?(xml_file)
+      return false
+    end
+
+    doc = REXML::Document.new(File.open(xml_file))
+
+    jdbc_provider_path = XPath.first(doc, "//resources.jdbc:JDBCProvider[@name='#{resource[:jdbc_provider]}']")
+    raise Puppet::Error, "JDBC provider #{resource[:jdbc_provider]} does not exist. Cannot create custom property: #{resource[:name]}." unless jdbc_provider_path
+    jdbc_datasource_path = XPath.first(jdbc_provider_path, "//factories[@name='#{resource[:jdbc_datasource]}']")
+    raise Puppet::Error, "JDBC datasource #{resource[:jdbc_datasource]} does not exist for #{resource[:jdbc_provider]}. Cannot create custom property: #{resource[:name]}." unless jdbc_datasource_path
+    custom_property_path = XPath.first(jdbc_datasource_path, "//propertySet/resourceProperties[@name='#{resource[:name]}']")
+
+    debug "Exists? Found match for #{resource[:name]}. Path #{custom_property_path}" if custom_property_path
+
+    unless custom_property_path
+      debug "jdbc datasource custom property #{resource[:name]} doesn't seem to exist."
+      return false
+    end
+
+    true
+  end
+
+  def create
+    attributes = [
+      ['name', resource[:name]],
+      ['type', "java.lang.#{resource[:java_type]}"],
+      ['value', resource[:property_value]],
+    ]
+    attributes << ['description', resource[:description]] if resource[:description]
+
+    cmd = <<-EOS
+id = AdminConfig.getid('#{scope('query')}')
+propSet = AdminConfig.showAttribute(id, 'propertySet')
+AdminConfig.create('J2EEResourceProperty', propSet, #{attributes})
+AdminConfig.save()
+EOS
+    debug "Running #{cmd}"
+    result = wsadmin(file: cmd, user: resource[:user])
+    debug result
+    @property_hash.clear
+  end
+
+  def property_value
+    get_property_value('value')
+  end
+
+  def property_value=(value)
+    @property_hash[:property_value] = value
+  end
+
+  def description
+    get_property_value('description')
+  end
+
+  def description=(value)
+    @property_hash[:description] = value
+  end
+
+  def destroy
+    cmd = <<-EOS
+AdminConfig.remove(AdminConfig.getid("#{scope('query')}J2EEResourcePropertySet:/J2EEResourceProperty:#{resource[:name]}"))
+AdminConfig.save()
+EOS
+    debug "Running #{cmd}"
+    result = wsadmin(file: cmd, user: resource[:user])
+    debug result
+    @property_hash.clear
+  end
+
+  # @private
+  # Helper method
+  def modified_attributes_list_list
+    # Only add defined values
+    list_list = []
+    list_list << ['value', @property_hash[:property_value]] if @property_hash[:property_value]
+    list_list << ['description', @property_hash[:description]] if @property_hash[:description]
+    list_list
+  end
+
+  def flush
+    return if @property_hash.empty?
+    cmd = <<-EOS
+id = AdminConfig.getid("#{scope('query')}J2EEResourcePropertySet:/J2EEResourceProperty:#{resource[:name]}")
+AdminConfig.modify(id, #{modified_attributes_list_list})
+AdminConfig.save()
+EOS
+    debug "Running #{cmd}"
+    result = wsadmin(file: cmd, user: resource[:user])
+    debug result
+    case resource[:scope]
+    when %r{(server|node)}
+      sync_node
+    end
+  end
+end

--- a/lib/puppet/provider/websphere_jdbc_datasource_custom_property/wsadmin.rb
+++ b/lib/puppet/provider/websphere_jdbc_datasource_custom_property/wsadmin.rb
@@ -63,9 +63,9 @@ Puppet::Type.type(:websphere_jdbc_datasource_custom_property).provide(:wsadmin, 
 
     jdbc_provider_path = XPath.first(doc, "//resources.jdbc:JDBCProvider[@name='#{resource[:jdbc_provider]}']")
     raise Puppet::Error, "JDBC provider #{resource[:jdbc_provider]} does not exist. Cannot create custom property: #{resource[:name]}." unless jdbc_provider_path
-    jdbc_datasource_path = XPath.first(jdbc_provider_path, "//factories[@name='#{resource[:jdbc_datasource]}']")
+    jdbc_datasource_path = XPath.first(jdbc_provider_path, "factories[@name='#{resource[:jdbc_datasource]}']")
     raise Puppet::Error, "JDBC datasource #{resource[:jdbc_datasource]} does not exist for #{resource[:jdbc_provider]}. Cannot create custom property: #{resource[:name]}." unless jdbc_datasource_path
-    custom_property_path = XPath.first(jdbc_datasource_path, "//propertySet/resourceProperties[@name='#{resource[:name]}']")
+    custom_property_path = XPath.first(jdbc_datasource_path, "propertySet/resourceProperties[@name='#{resource[:name]}']")
 
     debug "Exists? Found match for #{resource[:name]}. Path #{custom_property_path}" if custom_property_path
 

--- a/lib/puppet/provider/websphere_jdbc_datasource_jaas_auth_data/wsadmin.rb
+++ b/lib/puppet/provider/websphere_jdbc_datasource_jaas_auth_data/wsadmin.rb
@@ -1,0 +1,136 @@
+require_relative '../websphere_helper'
+#
+Puppet::Type.type(:websphere_jdbc_datasource_jaas_auth_data).provide(:wsadmin, parent: Puppet::Provider::Websphere_Helper) do
+  desc 'wsadmin provider for `websphere_jdbc_datasource_jaas_auth_data`'
+
+  def exists?
+    xml_file = resource[:profile_base] + '/' + resource[:dmgr_profile] + '/config/cells/' + resource[:cell] + '/security.xml'
+    unless File.exist?(xml_file)
+      return false
+    end
+    doc = REXML::Document.new(File.open(xml_file))
+    path = REXML::XPath.first(doc, "//security:Security/authDataEntries[@alias='#{resource[:name]}'])")
+
+    path ? true : false
+  end
+
+  def create
+    jaas_attributes = [['alias', resource[:name]], ['userId', resource[:user_id]], ['password', resource[:password]], ['description', resource[:description]]]
+
+    cmd = <<-EOS
+security = AdminConfig.getid('/Cell:#{resource[:cell]}/Security:/');
+AdminConfig.create('JAASAuthData', security, #{jaas_attributes});
+AdminConfig.save();
+EOS
+
+    debug "Running #{cmd}"
+    result = wsadmin(file: cmd, user: resource[:user])
+    debug "Created JAAS auth data #{name}. result: #{result}"
+    @property_hash.clear
+  end
+
+  def destroy
+    # AdminConfig.getid('/Cell:CELL_01/Security:/JAASAuthData:/')
+    cmd = <<-EOS
+jaasAuthData = AdminConfig.getid('/Cell:#{resource[:cell]}/Security:/JAASAuthData:/').splitlines();
+for jaas in jaasAuthData:
+  if (AdminConfig.showAttribute(jaas, 'alias') == "#{resource[:name]}"):
+    AdminConfig.remove(jaas);
+AdminConfig.save();
+EOS
+    debug "Running #{cmd}"
+    result = wsadmin(file: cmd, user: resource[:user])
+    debug "Removed JAAS auth data #{resource[:name]}. result: #{result}"
+    @property_hash.clear
+  end
+
+  # @private
+  # Helper method
+  def get_property_value(prop)
+    xml_file = resource[:profile_base] + '/' + resource[:dmgr_profile] + '/config/cells/' + resource[:cell] + '/security.xml'
+
+    unless File.exist?(xml_file)
+      return false
+    end
+
+    doc = REXML::Document.new(File.open(xml_file))
+    path = REXML::XPath.first(doc, "//security:Security/authDataEntries[@alias='#{resource[:name]}'])")
+
+    unless path
+      return nil
+    end
+    value = REXML::XPath.first(path, "@#{prop}")
+    debug "Exists? Found match for #{resource[:name]}. #{prop} is: #{value}" if value
+
+    value.nil? ? nil : value.to_s
+  end
+
+  def password
+    value = get_property_value('password')
+
+    # compare encrypted password from XML to the password defined that we'll encrpyt
+    install_path = resource[:profile_base].split('/')[0..-2].join('/')
+    java_path = "#{install_path}/java/bin/java"
+
+    unless File.exist?(java_path)
+      # Try to find java install
+      # WebSphere9 doesn't come with Java prepackaged
+      java_path = "#{install_path}/java/8.0/bin/java"
+      unless File.exist?(java_path)
+        raise Error, 'Cannot configure password for JAAS auth data. Java not found in hardcoded locations.'
+      end
+    end
+    cmd               = "#{java_path} -Xmx12m -Djava.ext.dirs=#{install_path}/plugins:#{install_path}/lib com.ibm.ws.security.util.PasswordEncoder '#{resource[:password]}'"
+    new_password_xor  = `#{cmd}`
+    new_password_xor  = new_password_xor.split.last[1..-2]
+
+    (value.to_s == new_password_xor.to_s) ? resource[:password] : 'different'
+  end
+
+  def user_id
+    value = get_property_value('userId')
+    value.nil? ? nil : value.to_s
+  end
+
+  def description
+    value = get_property_value('description')
+    value.nil? ? nil : value.to_s
+  end
+
+  def password=(value)
+    @property_hash[:password] = value
+  end
+
+  def user_id=(value)
+    @property_hash[:user_id] = value
+  end
+
+  def description=(value)
+    @property_hash[:description] = value
+  end
+
+  # @private
+  # Helper method
+  def modified_attributes_list_list
+    # Only add defined values
+    list_list = []
+    list_list << ['userId', @property_hash[:user_id]] if @property_hash[:user_id]
+    list_list << ['password', @property_hash[:password]] if @property_hash[:password]
+    list_list << ['description', @property_hash[:description]] if @property_hash[:description]
+    list_list
+  end
+
+  def flush
+    return if @property_hash.empty?
+    cmd = <<-EOS
+jaasAuthData = AdminConfig.getid('/Cell:#{resource[:cell]}/Security:/JAASAuthData:/').splitlines();
+for jaas in jaasAuthData:
+    if (AdminConfig.showAttribute(jaas, 'alias') == "#{resource[:name]}"):
+        AdminConfig.modify(jaas, #{modified_attributes_list_list});
+AdminConfig.save();
+EOS
+    debug "Running #{cmd}"
+    result = wsadmin(file: cmd, user: resource[:user])
+    debug result
+  end
+end

--- a/lib/puppet/provider/websphere_jvm_custom_property/wsadmin.rb
+++ b/lib/puppet/provider/websphere_jvm_custom_property/wsadmin.rb
@@ -1,0 +1,107 @@
+require_relative '../websphere_helper'
+#
+Puppet::Type.type(:websphere_jvm_custom_property).provide(:wsadmin, parent: Puppet::Provider::Websphere_Helper) do
+  # @private
+  # Helper method
+  def get_property_value(prop)
+    xml_file = "#{resource[:profile_base]}/#{resource[:dmgr_profile]}/config/cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/servers/#{resource[:server]}/server.xml"
+    doc = REXML::Document.new(File.open(xml_file))
+    path = REXML::XPath.first(doc, "//processDefinitions/jvmEntries/systemProperties[@name='#{resource[:name]}']")
+    value = REXML::XPath.first(path, "@#{prop}").to_s if path
+
+    debug "Exists? Found match for #{resource[:name]}. #{prop} is: #{value}" if value
+    value
+  end
+
+  def exists?
+    xml_file = "#{resource[:profile_base]}/#{resource[:dmgr_profile]}/config/cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/servers/#{resource[:server]}/server.xml"
+
+    unless File.exist?(xml_file)
+      return false
+    end
+
+    doc = REXML::Document.new(File.open(xml_file))
+
+    path = XPath.first(doc, "//processDefinitions/jvmEntries/systemProperties[@name='#{resource[:name]}']")
+
+    debug "Exists? Found match for #{resource[:name]}. Path #{path}" if path
+
+    unless path
+      debug "custom property #{resource[:name]} doesn't seem to exist."
+      return false
+    end
+
+    true
+  end
+
+  def create
+    attributes = [
+      ['name', resource[:name]],
+      ['value', resource[:property_value]],
+    ]
+    attributes << ['description', resource[:description]] if resource[:description]
+
+    query = '/Cell:' + "#{resource[:cell]}/" + 'Node:' + "#{resource[:node_name]}/" + 'Server:' + "#{resource[:server]}/JavaProcessDef:/JavaVirtualMachine:/"
+    cmd = <<-EOS
+id = AdminConfig.getid('#{query}')
+AdminConfig.create('Property', id, #{attributes})
+AdminConfig.save()
+EOS
+    debug "Running #{cmd}"
+    result = wsadmin(file: cmd, user: resource[:user])
+    debug result
+    @property_hash.clear
+  end
+
+  def property_value
+    get_property_value('value')
+  end
+
+  def property_value=(value)
+    @property_hash[:property_value] = value
+  end
+
+  def description
+    get_property_value('description')
+  end
+
+  def description=(value)
+    @property_hash[:description] = value
+  end
+
+  def destroy
+    query = '/Cell:' + "#{resource[:cell]}/" + 'Node:' + "#{resource[:node_name]}/" + 'Server:' + "#{resource[:server]}/JavaProcessDef:/JavaVirtualMachine:/Property:#{resource[:name]}/"
+    cmd = <<-EOS
+AdminConfig.remove(AdminConfig.getid("#{query}"))
+AdminConfig.save()
+EOS
+    debug "Running #{cmd}"
+    result = wsadmin(file: cmd, user: resource[:user])
+    debug result
+    @property_hash.clear
+  end
+
+  # @private
+  # Helper method
+  def modified_attributes_list_list
+    # Only add defined values
+    list_list = []
+    list_list << ['value', @property_hash[:property_value]] if @property_hash[:property_value]
+    list_list << ['description', @property_hash[:description]] if @property_hash[:description]
+    list_list
+  end
+
+  def flush
+    return if @property_hash.empty?
+    query = '/Cell:' + "#{resource[:cell]}/" + 'Node:' + "#{resource[:node_name]}/" + 'Server:' + "#{resource[:server]}/JavaProcessDef:/JavaVirtualMachine:/Property:#{resource[:name]}/"
+    cmd = <<-EOS
+id = AdminConfig.getid("#{query}")
+AdminConfig.modify(id, #{modified_attributes_list_list})
+AdminConfig.save()
+EOS
+    debug "Running #{cmd}"
+    result = wsadmin(file: cmd, user: resource[:user])
+    debug result
+    sync_node
+  end
+end

--- a/lib/puppet/provider/websphere_namespace_binding/wsadmin.rb
+++ b/lib/puppet/provider/websphere_namespace_binding/wsadmin.rb
@@ -1,0 +1,309 @@
+require_relative '../websphere_helper'
+#
+Puppet::Type.type(:websphere_namespace_binding).provide(:wsadmin, parent: Puppet::Provider::Websphere_Helper) do
+  # @private
+  # Helper method
+  def scope(what)
+    file = "#{resource[:profile_base]}/#{resource[:dmgr_profile]}"
+    case resource[:scope]
+    when 'cell'
+      query = '/Cell:' + "#{resource[:cell]}/"
+      file += "/config/cells/#{resource[:cell]}/namebindings.xml"
+    when 'node'
+      query = '/Cell:' + "#{resource[:cell]}/" + 'Node:' + "#{resource[:node_name]}/"
+      file += "/config/cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/namebindings.xml"
+    when 'server'
+      query = '/Cell:' + "#{resource[:cell]}/" + 'Node:' + "#{resource[:node_name]}/" + 'Server:' + "#{resource[:server]}/"
+      file += "/config/cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/servers/#{resource[:server]}/namebindings.xml"
+    when 'cluster'
+      query = '/Cell:' + "#{resource[:cell]}/" + 'ServerCluster:' + "#{resource[:cluster]}/"
+      file += "/config/cells/#{resource[:cell]}/clusters/#{resource[:cluster]}/namebindings.xml"
+    else
+      raise Puppet::Error, "Unknown scope: #{resource[:scope]}"
+    end
+
+    case what
+    when 'query'
+      query
+    when 'file'
+      file
+    else
+      debug 'Invalid scope request'
+    end
+  end
+
+  # @private
+  # Helper method
+  # Need to have double quotes around the values within the command
+  def bind(what)
+    scope = scope('query')
+
+    case resource[:binding_type]
+    when 'string'
+      cmd = '"' + "AdminConfig.create('StringNameSpaceBinding', AdminConfig.getid("
+      cmd += "'#{scope}'),'["
+      cmd += '[name ' + '\"' + resource[:name] + '\"] '
+      cmd += '[nameInNameSpace ' + '\"' + resource[:name_in_name_space] + '\"] '
+      cmd += '[stringToBind ' + '\"' + resource[:string_to_bind] + '\"]' + "]')" + '"'
+      object = 'StringNameSpaceBinding'
+    when 'ejb'
+      cmd =  '"' + "AdminConfig.create('EjbNameSpaceBinding', AdminConfig.getid("
+      cmd += "'#{scope}'),'["
+      cmd += '[name ' + '\"' + resource[:name] + '\"] '
+      cmd += '[nameInNameSpace ' + '\"' + resource[:name_in_name_space] + '\"] '
+      cmd += '[ejbJndiName ' + '\"' + resource[:ejb_jndi_name] + '\"] '
+      cmd += '[applicationServerName ' + '\"' + resource[:application_server_name] + '\"] ' if resource[:application_server_name]
+      cmd += '[applicationNodeName ' + '\"' + resource[:application_node_name] + '\"]' if resource[:application_node_name]
+      cmd += "]')" + '"'
+      object = 'EjbNameSpaceBinding'
+    when 'corba'
+      cmd = '"' + "AdminConfig.create('CORBAObjectNameSpaceBinding', AdminConfig.getid("
+      cmd += "'#{scope}'),'["
+      cmd += '[name ' + '\"' + resource[:name] + '\"] '
+      cmd += '[nameInNameSpace ' + '\"' + resource[:name_in_name_space] + '\"] '
+      cmd += '[corbanameUrl ' + '\"' + resource[:corbaname_url] + '\"] '
+      cmd += '[federatedContext ' + '\"' + resource[:federated_context] + '\"]' + "]')" + '"'
+      object = 'CORBAObjectNameSpaceBinding'
+    when 'indirect'
+      cmd = '"' + "AdminConfig.create('IndirectLookupNameSpaceBinding', AdminConfig.getid("
+      cmd += "'#{scope}'),'["
+      cmd += '[name ' + '\"' + resource[:name] + '\"] '
+      cmd += '[nameInNameSpace ' + '\"' + resource[:name_in_name_space] + '\"] '
+      cmd += '[providerURL ' + '\"' + resource[:provider_url] + '\"] '
+      cmd += '[initialContextFactory ' + '\"' + resource[:initial_context_factory] + '\"] '
+      cmd += '[jndiName ' + '\"' + resource[:jndi_name] + '\"]' + "]')" + '"'
+      object = 'IndirectLookupNameSpaceBinding'
+    else
+      raise Puppet::Error, "Unknown binding_type: #{resource[:binding_type]}"
+    end
+
+    case what
+    when 'cmd'
+      cmd
+    when 'object'
+      object
+    else
+      debug 'Invalid object request'
+    end
+  end
+
+  # @private
+  # Helper method
+  def get_property_value(prop)
+    bind_object = bind('object')
+    name_bindings_xml = scope('file')
+
+    unless File.exist?(name_bindings_xml)
+      return false
+    end
+
+    doc = REXML::Document.new(File.open(name_bindings_xml))
+
+    path = XPath.first(doc, "//namebindings:#{bind_object}[@name='#{resource[:name]}']")
+    value = XPath.first(path, "@#{prop}").to_s if path
+
+    debug "Exists? Found match for #{resource[:name]}. #{prop} is: #{value}" if value
+    value
+  end
+
+  def exists?
+    bind_object = bind('object')
+    name_bindings_xml = scope('file')
+
+    unless File.exist?(name_bindings_xml)
+      return false
+    end
+
+    doc = REXML::Document.new(File.open(name_bindings_xml))
+
+    path = XPath.first(doc, "//namebindings:#{bind_object}[@name='#{resource[:name]}']")
+
+    debug "Exists? Found match for #{resource[:name]}. Path #{path}" if path
+
+    unless path
+      debug "namespace binding #{resource[:name]} doesn't seem to exist"
+      return false
+    end
+
+    true
+  end
+
+  def create
+    cmd = bind('cmd')
+    debug "Running #{cmd}"
+    result = wsadmin(command: cmd, user: resource[:user])
+    debug result
+    @property_hash.clear
+  end
+
+  def name_in_name_space
+    get_property_value('nameInNameSpace')
+  end
+
+  def name_in_name_space=(value)
+    @property_hash[:name_in_name_space] = value
+  end
+
+  # corba
+  def corbaname_url
+    unless resource[:binding_type] == 'corba'
+      return nil
+    end
+    get_property_value('corbanameUrl')
+  end
+
+  # corba
+  def corbaname_url=(value)
+    @property_hash[:corbaname_url] = value
+  end
+
+  # corba
+  def federated_context
+    unless resource[:binding_type] == 'corba'
+      return nil
+    end
+    get_property_value('federatedContext')
+  end
+
+  # corba
+  def federated_context=(value)
+    @property_hash[:federated_context] = value
+  end
+
+  # string
+  def string_to_bind
+    unless resource[:binding_type] == 'string'
+      return nil
+    end
+    get_property_value('stringToBind')
+  end
+
+  # string
+  def string_to_bind=(value)
+    @property_hash[:string_to_bind] = value
+  end
+
+  # ejb
+  def application_node_name
+    unless resource[:binding_type] == 'ejb'
+      return nil
+    end
+    get_property_value('applicationNodeName')
+  end
+
+  # ejb
+  def application_node_name=(value)
+    @property_hash[:application_node_name] = value
+  end
+
+  # ejb
+  def application_server_name
+    unless resource[:binding_type] == 'ejb'
+      return nil
+    end
+    get_property_value('applicationServerName')
+  end
+
+  # ejb
+  def application_server_name=(value)
+    @property_hash[:application_server_name] = value
+  end
+
+  # ejb
+  def ejb_jndi_name
+    unless resource[:binding_type] == 'ejb'
+      return nil
+    end
+    get_property_value('ejbJndiName')
+  end
+
+  # ejb
+  def ejb_jndi_name=(value)
+    @property_hash[:ejb_jndi_name] = value
+  end
+
+  # indirect
+  def provider_url
+    unless resource[:binding_type] == 'indirect'
+      return nil
+    end
+    get_property_value('providerURL')
+  end
+
+  # indirect
+  def provider_url=(value)
+    @property_hash[:provider_url] = value
+  end
+
+  # indirect
+  def initial_context_factory
+    unless resource[:binding_type] == 'indirect'
+      return nil
+    end
+    get_property_value('initialContextFactory')
+  end
+
+  # indirect
+  def initial_context_factory=(value)
+    @property_hash[:initial_context_factory] = value
+  end
+
+  # indirect
+  def jndi_name
+    unless resource[:binding_type] == 'indirect'
+      return nil
+    end
+    get_property_value('jndiName')
+  end
+
+  # indirect
+  def jndi_name=(value)
+    @property_hash[:jndi_name] = value
+  end
+
+  def destroy
+    cmd = <<-EOS
+AdminConfig.remove(AdminConfig.getid(\"#{scope('query')}#{bind('object')}:#{resource[:name]}\"))
+AdminConfig.save()
+EOS
+    debug "Running #{cmd}"
+    result = wsadmin(file: cmd, user: resource[:user])
+    debug result
+    @property_hash.clear
+  end
+
+  # @private
+  # Helper method
+  def modified_attributes_list_list
+    # Only add defined values
+    list_list = []
+    list_list << ['nameInNameSpace', @property_hash[:name_in_name_space]] if @property_hash[:name_in_name_space]
+    list_list << ['corbanameUrl', @property_hash[:corbaname_url]] if @property_hash[:corbaname_url]
+    list_list << ['federatedContext', @property_hash[:federated_context]] if @property_hash[:federated_context]
+    list_list << ['stringToBind', @property_hash[:string_to_bind]] if @property_hash[:string_to_bind]
+    list_list << ['applicationNodeName', @property_hash[:application_node_name]] if @property_hash[:application_node_name]
+    list_list << ['applicationServerName', @property_hash[:application_server_name]] if @property_hash[:application_server_name]
+    list_list << ['ejbJndiName', @property_hash[:ejb_jndi_name]] if @property_hash[:ejb_jndi_name]
+    list_list << ['providerURL', @property_hash[:provider_url]] if @property_hash[:provider_url]
+    list_list << ['initialContextFactory', @property_hash[:initial_context_factory]] if @property_hash[:initial_context_factory]
+    list_list << ['jndiName', @property_hash[:jndi_name]] if @property_hash[:jndi_name]
+    list_list
+  end
+
+  def flush
+    return if @property_hash.empty?
+    cmd = <<-EOS
+id = AdminConfig.getid(\"#{scope('query')}#{bind('object')}:#{resource[:name]}\")
+AdminConfig.modify(id, #{modified_attributes_list_list})
+AdminConfig.save()
+EOS
+    debug 'flushing namespace bindings'
+    debug "Running #{cmd}"
+    result = wsadmin(file: cmd, user: resource[:user])
+    debug result
+    case resource[:scope]
+    when %r{(server|node)}
+      sync_node
+    end
+  end
+end

--- a/lib/puppet/provider/websphere_security_custom_property/wsadmin.rb
+++ b/lib/puppet/provider/websphere_security_custom_property/wsadmin.rb
@@ -1,0 +1,108 @@
+require_relative '../websphere_helper'
+#
+Puppet::Type.type(:websphere_security_custom_property).provide(:wsadmin, parent: Puppet::Provider::Websphere_Helper) do
+  desc 'wsadmin provider for `websphere_security_custom_property`'
+
+  # @private
+  # Helper method
+  def get_property_value(prop)
+    xml_file = resource[:profile_base] + '/' + resource[:profile] + '/config/cells/' + resource[:cell] + '/security.xml'
+    return nil unless File.exist?(xml_file)
+    doc = REXML::Document.new(File.open(xml_file))
+    path = REXML::XPath.first(doc, "//properties[@name='#{resource[:name]}']")
+    value = REXML::XPath.first(path, "@#{prop}").to_s if path
+
+    debug "Exists? Found match for #{resource[:name]}. #{prop} is: #{value}" if value
+    value
+  end
+
+  def exists?
+    security_xml = resource[:profile_base] + '/' + resource[:profile] + '/config/cells/' + resource[:cell] + '/security.xml'
+
+    return false unless File.exist?(security_xml)
+
+    doc = REXML::Document.new(File.open(security_xml))
+
+    path = XPath.first(doc, "//properties[@name='#{resource[:name]}']")
+    debug "Exists? Found match for #{resource[:name]}. Path #{path}" if path
+
+    unless path
+      debug "Security custom property #{resource[:name]} does not exist."
+      return false
+    end
+
+    true
+  end
+
+  def create
+    attributes = [
+      ['name', resource[:name]],
+      ['value', resource[:property_value]],
+    ]
+    attributes << ['description', resource[:description]] if resource[:description]
+
+    cmd = <<-EOS
+security = AdminConfig.getid('/Cell:#{resource[:cell]}/Security:/');
+AdminConfig.create('Property', security, #{attributes});
+AdminConfig.save();
+EOS
+    debug "Running #{cmd}"
+    result = wsadmin(file: cmd, user: resource[:user])
+    debug "Created Security Custom Property. result: #{result}"
+  end
+
+  def destroy
+    # AdminConfig.remove('(cells/CELL_01|security.xml#Property_1587485876321)')
+    # AdminConfig.getid('/Security:/Property:com.ibm.websphere.tls.disabledAlgorithms')
+    cmd = <<-EOT
+    \"AdminConfig.remove(AdminConfig.getid('/Cell:#{resource[:cell]}/Security:/Property:#{resource[:name]}/'))
+    AdminConfig.save()\"
+    EOT
+    debug "Running #{cmd}"
+    result = wsadmin(command: cmd, user: resource[:user])
+    debug "Removed Security Custom Property #{resource[:name]}. result: #{result}"
+  end
+
+  def property_value
+    value = get_property_value('value')
+    value = value.gsub(%r{&lt;}, '<')
+    value = value.gsub(%r{&gt;}, '>')
+    value
+  end
+
+  def property_value=(value)
+    @property_hash[:property_value] = value
+  end
+
+  def description
+    get_property_value('description')
+  end
+
+  def description=(value)
+    @property_hash[:description] = value
+  end
+
+  # @private
+  # Helper method
+  def modified_attributes_list_list
+    # Only add defined values
+    list_list = []
+    list_list << ['value', @property_hash[:property_value]] if @property_hash[:property_value]
+    list_list << ['description', @property_hash[:description]] if @property_hash[:description]
+    list_list
+  end
+
+  def flush
+    return if @property_hash.empty?
+    cmd = <<-EOS
+id = AdminConfig.getid('/Cell:#{resource[:cell]}/Security:/Property:#{resource[:name]}')
+AdminConfig.modify(id, #{modified_attributes_list_list})
+AdminConfig.save()
+EOS
+    debug "Running #{cmd}"
+    result = wsadmin(file: cmd, user: resource[:user])
+    debug result
+
+    sync_node
+  end
+end

--- a/lib/puppet/provider/websphere_shared_library/wsadmin.rb
+++ b/lib/puppet/provider/websphere_shared_library/wsadmin.rb
@@ -1,0 +1,183 @@
+require_relative '../websphere_helper'
+#
+Puppet::Type.type(:websphere_shared_library).provide(:wsadmin, parent: Puppet::Provider::Websphere_Helper) do
+  # @private
+  # Helper method
+  def scope(what)
+    file = "#{resource[:profile_base]}/#{resource[:dmgr_profile]}"
+    case resource[:scope]
+    when 'cell'
+      query = '/Cell:' + "#{resource[:cell]}/"
+      file += "/config/cells/#{resource[:cell]}/libraries.xml"
+    when 'node'
+      query = '/Cell:' + "#{resource[:cell]}/" + 'Node:' + "#{resource[:node_name]}/"
+      file += "/config/cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/libraries.xml"
+    when 'server'
+      query = '/Cell:' + "#{resource[:cell]}/" + 'Node:' + "#{resource[:node_name]}/" + 'Server:' + "#{resource[:server]}/"
+      file += "/config/cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/servers/#{resource[:server]}/libraries.xml"
+    when 'cluster'
+      query = '/Cell:' + "#{resource[:cell]}/" + 'ServerCluster:' + "#{resource[:cluster]}/"
+      file += "/config/cells/#{resource[:cell]}/clusters/#{resource[:cluster]}/libraries.xml"
+    else
+      raise Puppet::Error, "Unknown scope: #{resource[:scope]}"
+    end
+
+    case what
+    when 'query'
+      query
+    when 'file'
+      file
+    else
+      debug 'Invalid scope request'
+    end
+  end
+
+  # @private
+  # Helper method
+  def get_property_value(prop)
+    xml_file = scope('file')
+
+    unless File.exist?(xml_file)
+      return false
+    end
+
+    doc = REXML::Document.new(File.open(xml_file))
+
+    path = XPath.first(doc, "//libraries:Library[@name='#{resource[:name]}']")
+    value = XPath.first(path, "@#{prop}").to_s if path
+
+    debug "Exists? Found match for #{resource[:name]}. #{prop} is: #{value}" if value
+    value
+  end
+
+  # @private
+  # Helper method
+  def get_property_value_array(prop)
+    xml_file = scope('file')
+
+    unless File.exist?(xml_file)
+      return false
+    end
+
+    doc = REXML::Document.new(File.open(xml_file))
+
+    values = []
+    XPath.each(doc, "//libraries:Library[@name='#{resource[:name]}']/#{prop}") do |el|
+      values << el.text
+    end
+    debug "Exists? Found match for #{resource[:name]}. #{prop} is: #{values}" unless values.empty?
+    values
+  end
+
+  def exists?
+    xml_file = scope('file')
+
+    unless File.exist?(xml_file)
+      return false
+    end
+
+    doc = REXML::Document.new(File.open(xml_file))
+
+    path = XPath.first(doc, "//libraries:Library[@name='#{resource[:name]}']")
+
+    debug "Exists? Found match for #{resource[:name]}. Path #{path}" if path
+
+    unless path
+      debug "shared library #{resource[:name]} doesn't seem to exist"
+      return false
+    end
+
+    true
+  end
+
+  def create
+    class_paths = resource[:class_path].empty? ? '' : resource[:class_path].join(';')
+    native_paths = resource[:native_path].empty? ? '' : resource[:native_path].join(';')
+    attributes = [
+      ['name', resource[:name]],
+      ['classPath', class_paths], ['nativePath', native_paths],
+      ['isolatedClassLoader', resource[:isolated_class_loader]],
+      ['description', resource[:description]]
+    ]
+
+    cmd = <<-EOS
+AdminConfig.create('Library', AdminConfig.getid('#{scope('query')}'), #{attributes})
+AdminConfig.save()
+EOS
+    debug "Running #{cmd}"
+    result = wsadmin(file: cmd, user: resource[:user])
+    debug result
+    @property_hash.clear
+  end
+
+  def class_path
+    get_property_value_array('classPath')
+  end
+
+  def class_path=(value)
+    @property_hash[:class_path] = value
+  end
+
+  def native_path
+    get_property_value_array('nativePath')
+  end
+
+  def native_path=(value)
+    @property_hash[:native_path] = value
+  end
+
+  def isolated_class_loader
+    get_property_value('isolatedClassLoader')
+  end
+
+  def isolated_class_loader=(value)
+    @property_hash[:isolated_class_loader] = value
+  end
+
+  def description
+    get_property_value('description')
+  end
+
+  def description=(value)
+    @property_hash[:description] = value
+  end
+
+  def destroy
+    cmd = <<-EOS
+AdminConfig.remove(AdminConfig.getid(\"#{scope('query')}Library:#{resource[:name]}\"))
+AdminConfig.save()
+EOS
+    debug "Running #{cmd}"
+    result = wsadmin(file: cmd, user: resource[:user])
+    debug result
+    @property_hash.clear
+  end
+
+  # @private
+  # Helper method
+  def modified_attributes_list_list
+    # Only add defined values
+    list_list = []
+    list_list << ['classPath', @property_hash[:class_path].join(';')] if @property_hash[:class_path]
+    list_list << ['nativePath', @property_hash[:native_path].join(';')] if @property_hash[:native_path]
+    list_list << ['isolatedClassLoader', @property_hash[:isolated_class_loader]] if @property_hash[:isolated_class_loader]
+    list_list << ['description', @property_hash[:description]] if @property_hash[:description]
+    list_list
+  end
+
+  def flush
+    return if @property_hash.empty?
+    cmd = <<-EOS
+id = AdminConfig.getid(\"#{scope('query')}Library:#{resource[:name]}\")
+AdminConfig.modify(id, #{modified_attributes_list_list})
+AdminConfig.save()
+EOS
+    debug "Running #{cmd}"
+    result = wsadmin(file: cmd, user: resource[:user])
+    debug result
+    case resource[:scope]
+    when %r{(server|node)}
+      sync_node
+    end
+  end
+end

--- a/lib/puppet/provider/websphere_variable/wsadmin.rb
+++ b/lib/puppet/provider/websphere_variable/wsadmin.rb
@@ -180,9 +180,9 @@ Puppet::Type.type(:websphere_variable).provide(:wsadmin, parent: Puppet::Provide
   end
 
   def flush
-    debug 'Initiating node synchronization'
-    sync_node
-    ## TODO: Need to handle this somehow.
-    # restart_server
+    case resource[:scope]
+    when %r{(server|node)}
+      sync_node
+    end
   end
 end

--- a/lib/puppet/type/websphere_jdbc_datasource_custom_property.rb
+++ b/lib/puppet/type/websphere_jdbc_datasource_custom_property.rb
@@ -1,0 +1,303 @@
+require 'pathname'
+
+Puppet::Type.newtype(:websphere_jdbc_datasource_custom_property) do
+  @doc = <<-DOC
+    @summary This manages WebSphere JDBC datasource custom properties.
+    @example
+      websphere_jdbc_datasource_custom_property { 'exampleCustomProperty':
+        ensure          => 'present',
+        dmgr_profile    => 'PROFILE_DMGR_01',
+        profile_base    => '/opt/IBM/WebSphere/AppServer/profiles',
+        user            => 'webadmin',
+        cell            => 'CELL_01',
+        node_name       => 'AppNode01',
+        cluster         => 'TEST_CLUSTER',
+        scope           => 'cluster',
+        java_type       => 'String',
+        jdbc_provider   => 'ORACLE_JDBC_DRIVER_TEST_CLUSTER',
+        jdbc_datasource => 'TEST_DS_01',
+        property_value  => 'ValueGoesHere',
+        description     => 'Created by Puppet',
+      }
+  DOC
+
+  # Our title_patterns method for mapping titles to namevars for supporting
+  # composite namevars.
+  def self.title_patterns
+    [
+      # PuppetTest
+      [
+        %r{^([^:]+)$},
+        [
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PuppetTest
+      [
+        %r{^(.*):(.*)$},
+        [
+          [:profile_base],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:PuppetTest
+      [
+        %r{^(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:cell:CELL_01:PuppetTest
+      [
+        %r{^(.*):(.*):(cell):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:scope],
+          [:cell],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:cluster:CELL_01:TEST_CLUSTER_01:PuppetTest
+      [
+        %r{^(.*):(.*):(cluster):(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:scope],
+          [:cell],
+          [:cluster],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:cluster:CELL_01:TEST_CLUSTER_01:JDBCProviderName:JDBCDatasourceName:PuppetTest
+      [
+        %r{^(.*):(.*):(cluster):(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:scope],
+          [:cell],
+          [:cluster],
+          [:jdbc_provider],
+          [:jdbc_datasource],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:node:CELL_01:AppNode01:PuppetTest
+      [
+        %r{^(.*):(.*):(node):(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:scope],
+          [:cell],
+          [:node_name],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:node:CELL_01:AppNode01:JDBCProviderName:JDBCDatasourceName:PuppetTest
+      [
+        %r{^(.*):(.*):(node):(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:scope],
+          [:cell],
+          [:node_name],
+          [:jdbc_provider],
+          [:jdbc_datasource],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:server:CELL_01:AppNode01:AppServer01:PuppetTest
+      [
+        %r{^(.*):(.*):(server):(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:scope],
+          [:cell],
+          [:node_name],
+          [:server],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:server:CELL_01:AppNode01:AppServer01:JDBCProviderName:JDBCDatasourceName:PuppetTest
+      [
+        %r{^(.*):(.*):(server):(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:scope],
+          [:cell],
+          [:node_name],
+          [:server],
+          [:jdbc_provider],
+          [:jdbc_datasource],
+          [:name],
+        ],
+      ],
+    ]
+  end
+
+  autorequire(:websphere_jdbc_provider) do
+    self[:jdbc_provider]
+  end
+
+  autorequire(:websphere_jdbc_datasource) do
+    self[:jdbc_datasource]
+  end
+
+  ensurable do
+    desc <<-EOT
+    Valid values: `present`, `absent`
+
+    Defaults to `true`.  Specifies whether this custom property should exist or not.
+    EOT
+
+    defaultto(:present)
+
+    newvalue(:present) do
+      provider.create
+    end
+
+    newvalue(:absent) do
+      provider.destroy
+    end
+  end
+
+  validate do
+    [:dmgr_profile, :name, :user, :node, :cell].each do |value|
+      raise ArgumentError, "Invalid #{value} #{self[value]}" unless value =~ %r{^[-0-9A-Za-z._]+$}
+    end
+
+    raise ArgumentError, "Invalid scope #{self[:scope]}: Must be cell, cluster, node, or server" unless self[:scope] =~ %r{^(cell|cluster|node|server)$}
+
+    raise ArgumentError, 'server is required when scope is server' if self[:server].nil? && self[:scope] == 'server'
+    raise ArgumentError, 'cell is a required attribute' if self[:cell].nil?
+    raise ArgumentError, 'node is required when scope is server, cell, or node' if self[:node_name].nil? && self[:scope] =~ %r{(server|cell|node)}
+    raise ArgumentError, 'cluster is required when scope is cluster' if self[:cluster].nil? && self[:scope] =~ %r{^cluster$}
+    raise ArgumentError, 'jdbc_datasource is required' if self[:jdbc_datasource].nil?
+    raise ArgumentError, 'jdbc_provider is required' if self[:jdbc_provider].nil?
+    raise("Invalid profile_base #{self[:profile_base]}") unless Pathname.new(self[:profile_base]).absolute?
+
+    if self[:profile].nil?
+      raise ArgumentError, 'profile is required' unless self[:dmgr_profile]
+      self[:profile] = self[:dmgr_profile]
+    end
+
+    unless self[:java_type] =~ %r{^(String|Integer|Double|Float|Short|Long|Byte|Boolean)$}
+      raise ArgumentError, "Invalid java_type #{self[:java_type]}: Must be String, Integer, Double, Float, Short, Long, Byte, or Boolean"
+    end
+  end
+
+  newparam(:name) do
+    isnamevar
+    desc 'The name of the resource'
+  end
+
+  newparam(:scope) do
+    isnamevar
+    desc <<-EOT
+    Required. The scope of this configuration.
+    Valid values: cell, node, cluster, node group or server .
+    If scope is node, the cell and the node must be specified in their parameters.
+    If scope is cluster, the cell and the cluster must be specified in their parameters.
+    If scope is server, the cell, the node, and the server must be specified in their parameters.
+    EOT
+  end
+
+  newparam(:jdbc_provider) do
+    isnamevar
+    desc <<-EOT
+    The name of the JDBC Provider to use.
+    EOT
+  end
+
+  newparam(:jdbc_datasource) do
+    isnamevar
+    desc <<-EOT
+    Required. The name of the JDBC Datasource to use.
+    EOT
+  end
+
+  newparam(:java_type) do
+    desc <<-EOT
+    Specifies the Java lang type of this property.
+    EOT
+  end
+
+  newproperty(:description) do
+    desc <<-EOT
+    The description of the datasource custom property.
+    EOT
+  end
+
+  newproperty(:property_value) do
+    desc <<-EOT
+    The value of the datasource custom property.
+    EOT
+  end
+
+  newparam(:node) do
+    isnamevar
+    desc 'The name of the node to create this application server on'
+  end
+
+  newparam(:cluster) do
+    isnamevar
+    desc 'The name of the cluster to create this application server on'
+  end
+
+  newparam(:server) do
+    isnamevar
+    desc 'The name of the server to create this application server on'
+  end
+
+  newparam(:cell) do
+    isnamevar
+    desc 'The name of the cell to create this application server on'
+  end
+
+  newparam(:profile) do
+    desc "The profile to run 'wsadmin' under"
+  end
+
+  newparam(:dmgr_profile) do
+    isnamevar
+    defaultto { @resource[:profile] }
+    desc <<-EOT
+    The dmgr profile that this variable should be set under.  Basically, where
+    are we finding `wsadmin`
+
+    This is synonomous with the 'profile' parameter.
+
+    Example: dmgrProfile01
+    EOT
+  end
+
+  newparam(:profile_base) do
+    isnamevar
+    desc <<-EOT
+    The base directory that profiles are stored.
+    Basically, where can we find the 'dmgr_profile' so we can run 'wsadmin'
+    Example: /opt/IBM/WebSphere/AppServer/profiles"
+    EOT
+  end
+
+  newparam(:user) do
+    defaultto 'root'
+    desc "The user to run 'wsadmin' with"
+  end
+
+  newparam(:wsadmin_user) do
+    desc 'The username for wsadmin authentication'
+  end
+
+  newparam(:wsadmin_pass) do
+    desc 'The password for wsadmin authentication'
+  end
+end

--- a/lib/puppet/type/websphere_jdbc_datasource_jaas_auth_data.rb
+++ b/lib/puppet/type/websphere_jdbc_datasource_jaas_auth_data.rb
@@ -1,0 +1,162 @@
+require 'pathname'
+
+Puppet::Type.newtype(:websphere_jdbc_datasource_jaas_auth_data) do
+  @doc = <<-DOC
+    @summary This manages WebSphere JDBC JAAS Auth Data. Also known as auth aliases.
+    @example
+      websphere_jdbc_datasource_jaas_auth_data { 'Puppet Test':
+        ensure                        => 'present',
+        dmgr_profile                  => 'PROFILE_DMGR_01',
+        profile_base                  => '/opt/IBM/WebSphere/AppServer/profiles',
+        user                          => 'webadmin',
+        cell                          => 'CELL_01',
+        node_name                     => 'AppNode01',
+        user_id                       => 'User_test',
+        password                      => 'password123',
+        description                   => 'Created by Puppet',
+      }
+  DOC
+
+  # Our title_patterns method for mapping titles to namevars for supporting
+  # composite namevars.
+  def self.title_patterns
+    [
+      # AuthAliasName
+      [
+        %r{^([^:]+)$},
+        [
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:AuthAliasName
+      [
+        %r{^(.*):(.*)$},
+        [
+          [:profile_base],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:CELL_01:AuthAliasName
+      [
+        %r{^(.*):(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:cell],
+          [:name],
+        ],
+      ],
+    ]
+  end
+
+  ensurable do
+    desc <<-EOT
+    Valid values: `present`, `absent`
+
+    Defaults to `true`. Specifies whether this JAAS auth data should exist or not.
+    EOT
+
+    defaultto(:present)
+
+    newvalue(:present) do
+      provider.create
+    end
+
+    newvalue(:absent) do
+      provider.destroy
+    end
+  end
+
+  validate do
+    [:dmgr_profile, :name, :user, :node, :cell].each do |value|
+      raise ArgumentError, "Invalid #{value} #{self[value]}" unless value =~ %r{^[-0-9A-Za-z._]+$}
+    end
+
+    raise ArgumentError, 'cell is a required attribute' if self[:cell].nil?
+    raise("Invalid profile_base #{self[:profile_base]}") unless Pathname.new(self[:profile_base]).absolute?
+
+    if self[:profile].nil?
+      raise ArgumentError, 'profile is required' unless self[:dmgr_profile]
+      self[:profile] = self[:dmgr_profile]
+    end
+  end
+
+  newproperty(:user_id) do
+    desc <<-EOT
+    The user id of the auth alias
+    EOT
+  end
+
+  newproperty(:password) do
+    desc <<-EOT
+    The password of the auth alias.
+    EOT
+  end
+
+  newproperty(:description) do
+    desc <<-EOT
+    The description of the auth alias.
+    EOT
+  end
+
+  newparam(:name) do
+    isnamevar
+    desc 'The name of the resource'
+  end
+
+  newparam(:node) do
+    desc 'The name of the node to create this application server on'
+  end
+
+  newparam(:cluster) do
+    desc 'The name of the cluster to create this application server on'
+  end
+
+  newparam(:server) do
+    desc 'The name of the server to create this application server on'
+  end
+
+  newparam(:cell) do
+    isnamevar
+    desc 'The name of the cell to create this application server on'
+  end
+
+  newparam(:profile) do
+    desc "The profile to run 'wsadmin' under"
+  end
+
+  newparam(:dmgr_profile) do
+    isnamevar
+    defaultto { @resource[:profile] }
+    desc <<-EOT
+    The dmgr profile that this variable should be set under.  Basically, where
+    are we finding `wsadmin`
+
+    This is synonomous with the 'profile' parameter.
+
+    Example: dmgrProfile01"
+    EOT
+  end
+
+  newparam(:profile_base) do
+    isnamevar
+    desc <<-EOT
+    The base directory that profiles are stored.
+    Basically, where can we find the 'dmgr_profile' so we can run 'wsadmin'
+    Example: /opt/IBM/WebSphere/AppServer/profiles"
+    EOT
+  end
+
+  newparam(:user) do
+    defaultto 'root'
+    desc "The user to run 'wsadmin' with"
+  end
+
+  newparam(:wsadmin_user) do
+    desc 'The username for wsadmin authentication'
+  end
+
+  newparam(:wsadmin_pass) do
+    desc 'The password for wsadmin authentication'
+  end
+end

--- a/lib/puppet/type/websphere_jvm_custom_property.rb
+++ b/lib/puppet/type/websphere_jvm_custom_property.rb
@@ -1,0 +1,215 @@
+require 'pathname'
+
+Puppet::Type.newtype(:websphere_jvm_custom_property) do
+  @doc = <<-DOC
+    @summary This manages WebSphere jvm custom properties.
+    @example
+      websphere_jvm_custom_property { 'exampleCustomProperty':
+        ensure          => 'present',
+        dmgr_profile    => 'PROFILE_DMGR_01',
+        profile_base    => '/opt/IBM/WebSphere/AppServer/profiles',
+        user            => 'webadmin',
+        cell            => 'CELL_01',
+        node_name       => 'AppNode01',
+        server          => 'AppServer_01',
+        property_value  => 'ValueGoesHere',
+        description     => 'Created by Puppet',
+      }
+      # DMGR
+      websphere_jvm_custom_property { '/opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:CELL_01:DMGR_01:dmgr:PuppetTest':
+        ensure          => 'present',
+        dmgr_profile    => 'PROFILE_DMGR_01',
+        profile_base    => '/opt/IBM/WebSphere/AppServer/profiles',
+        user            => 'webadmin',
+        cell            => 'CELL_01',
+        node_name       => 'DMGR_01',
+        server          => 'dmgr',
+        property_value  => 'ValueGoesHere',
+        description     => 'Created by Puppet',
+      }
+      # AppServer nodeagent
+      websphere_jvm_custom_property { '/opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:CELL_01:AppNode_01:nodeagent:PuppetTest':
+        ensure          => 'present',
+        dmgr_profile    => 'PROFILE_DMGR_01',
+        profile_base    => '/opt/IBM/WebSphere/AppServer/profiles',
+        user            => 'webadmin',
+        cell            => 'CELL_01',
+        node_name       => 'AppNode_01',
+        server          => 'nodeagent',
+        property_value  => 'ValueGoesHere',
+        description     => 'Created by Puppet',
+      }
+  DOC
+
+  # Our title_patterns method for mapping titles to namevars for supporting
+  # composite namevars.
+  def self.title_patterns
+    [
+      # PuppetTest
+      [
+        %r{^([^:]+)$},
+        [
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PuppetTest
+      [
+        %r{^(.*):(.*)$},
+        [
+          [:profile_base],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:PuppetTest
+      [
+        %r{^(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:CELL_01:AppNode_01:AppServer01:PuppetTest
+      [
+        %r{^(.*):(.*):(.*):(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:cell],
+          [:node_name],
+          [:server],
+          [:name],
+        ],
+      ],
+    ]
+  end
+
+  ensurable do
+    desc <<-EOT
+    Valid values: `present`, `absent`
+
+    Defaults to `true`.  Specifies whether this custom property should exist or not.
+    EOT
+
+    defaultto(:present)
+
+    newvalue(:present) do
+      provider.create
+    end
+
+    newvalue(:absent) do
+      provider.destroy
+    end
+  end
+
+  validate do
+    [:dmgr_profile, :name, :user, :node, :cell].each do |value|
+      raise ArgumentError, "Invalid #{value} #{self[value]}" unless value =~ %r{^[-0-9A-Za-z._]+$}
+    end
+
+    raise ArgumentError, 'server is required attribute' if self[:server].nil?
+    raise ArgumentError, 'cell is a required attribute' if self[:cell].nil?
+    raise ArgumentError, 'node is required attribute' if self[:node_name].nil?
+    raise("Invalid profile_base #{self[:profile_base]}") unless Pathname.new(self[:profile_base]).absolute?
+
+    if self[:profile].nil?
+      raise ArgumentError, 'profile is required' unless self[:dmgr_profile]
+      self[:profile] = self[:dmgr_profile]
+    end
+  end
+
+  newparam(:name) do
+    isnamevar
+    desc 'The name of the resource'
+  end
+
+  newparam(:scope) do
+    isnamevar
+    desc <<-EOT
+    Required. The scope of this configuration.
+    Valid values: cell, node, cluster, node group or server .
+    If scope is node, the cell and the node must be specified in their parameters.
+    If scope is cluster, the cell and the cluster must be specified in their parameters.
+    If scope is server, the cell, the node, and the server must be specified in their parameters.
+    EOT
+  end
+
+  newproperty(:description) do
+    desc <<-EOT
+    The description of the datasource custom property.
+    EOT
+  end
+
+  newproperty(:property_value) do
+    desc <<-EOT
+    The value of the datasource custom property.
+    EOT
+  end
+
+  newparam(:node) do
+    isnamevar
+    desc 'The name of the node to create this application server on'
+  end
+
+  newparam(:cluster) do
+    desc 'The name of the cluster to create this application server on'
+  end
+
+  newparam(:server) do
+    isnamevar
+    desc 'The name of the server to create this application server on'
+  end
+
+  newparam(:cell) do
+    isnamevar
+    desc 'The name of the cell to create this application server on'
+  end
+
+  newparam(:profile) do
+    desc "The profile to run 'wsadmin' under"
+  end
+
+  newparam(:dmgr_profile) do
+    isnamevar
+    defaultto { @resource[:profile] }
+    desc <<-EOT
+    The dmgr profile that this variable should be set under.  Basically, where
+    are we finding `wsadmin`
+
+    This is synonomous with the 'profile' parameter.
+
+    Example: dmgrProfile01
+    EOT
+  end
+
+  newparam(:profile_base) do
+    isnamevar
+    desc <<-EOT
+    The base directory that profiles are stored.
+    Basically, where can we find the 'dmgr_profile' so we can run 'wsadmin'
+    Example: /opt/IBM/WebSphere/AppServer/profiles"
+    EOT
+  end
+
+  newparam(:user) do
+    defaultto 'root'
+    desc "The user to run 'wsadmin' with"
+  end
+
+  newparam(:wsadmin_user) do
+    desc 'The username for wsadmin authentication'
+  end
+
+  newparam(:wsadmin_pass) do
+    desc 'The password for wsadmin authentication'
+  end
+
+  newparam(:dmgr_host) do
+    desc <<-EOT
+      The DMGR host to add this cluster member to.
+
+      This is required if you're exporting the cluster member for a DMGR to
+      collect.  Otherwise, it's optional.
+    EOT
+  end
+end

--- a/lib/puppet/type/websphere_namespace_binding.rb
+++ b/lib/puppet/type/websphere_namespace_binding.rb
@@ -1,0 +1,374 @@
+require 'pathname'
+
+Puppet::Type.newtype(:websphere_namespace_binding) do
+  @doc = <<-DOC
+    @summary This manages WebSphere namespace bindings.
+    @example
+      websphere_namespace_binding { 'corbaPuppetTest':
+        ensure                        => 'present',
+        dmgr_profile                  => 'PROFILE_DMGR_01',
+        profile_base                  => '/opt/IBM/WebSphere/AppServer/profiles',
+        user                          => 'webadmin',
+        cell                          => 'CELL_01',
+        node_name                     => 'AppNode01',
+        cluster                       => 'TEST_CLUSTER',
+        scope                         => 'cluster',
+        binding_type                  => 'corba',
+        name_in_name_space            => 'corbaPuppetTestNameInNameSpace',
+        string_to_bind                => undef,
+        ejb_jndi_name                 => undef,
+        application_server_name       => undef,
+        application_node_name         => undef,
+        corbaname_url                 => 'corba.example.com',
+        federated_context             => false,
+        provider_url                  => undef,
+        initial_context_factory       => undef,
+        jndi_name                     => undef,
+      }
+      websphere_namespace_binding { 'ejbPuppetTest':
+        ensure                        => 'present',
+        dmgr_profile                  => 'PROFILE_DMGR_01',
+        profile_base                  => '/opt/IBM/WebSphere/AppServer/profiles',
+        user                          => 'webadmin',
+        cell                          => 'CELL_01',
+        node_name                     => 'AppNode01',
+        cluster                       => 'TEST_CLUSTER',
+        scope                         => 'cluster',
+        binding_type                  => 'ejb',
+        name_in_name_space            => 'ejbPuppetNameInNameSpace',
+        string_to_bind                => undef,
+        ejb_jndi_name                 => 'jndiNameExample',
+        application_server_name       => 'example.com',
+        application_node_name         => undef,
+        corbaname_url                 => undef,
+        federated_context             => undef,
+        provider_url                  => undef,
+        initial_context_factory       => undef,
+        jndi_name                     => undef,
+      }
+      websphere_namespace_binding { 'stringPuppetTest':
+        ensure                        => 'present',
+        dmgr_profile                  => 'PROFILE_DMGR_01',
+        profile_base                  => '/opt/IBM/WebSphere/AppServer/profiles',
+        user                          => 'webadmin',
+        cell                          => 'CELL_01',
+        node_name                     => 'AppNode01',
+        cluster                       => 'TEST_CLUSTER',
+        scope                         => 'cluster',
+        binding_type                  => 'string',
+        name_in_name_space            => 'stringPuppetNameInNameSpace',
+        string_to_bind                => 'PuppetString',
+        ejb_jndi_name                 => undef,
+        application_server_name       => undef,
+        application_node_name         => undef,
+        corbaname_url                 => undef,
+        federated_context             => undef,
+        provider_url                  => undef,
+        initial_context_factory       => undef,
+        jndi_name                     => undef,
+      }
+      websphere_namespace_binding { 'indirectPuppetTest':
+        ensure                        => 'present',
+        dmgr_profile                  => 'PROFILE_DMGR_01',
+        profile_base                  => '/opt/IBM/WebSphere/AppServer/profiles',
+        user                          => 'webadmin',
+        cell                          => 'CELL_01',
+        node_name                     => 'AppNode01',
+        cluster                       => 'TEST_CLUSTER',
+        scope                         => 'cluster',
+        binding_type                  => 'indirect',
+        name_in_name_space            => 'indirectPuppetNameInNameSpace',
+        string_to_bind                => undef,
+        ejb_jndi_name                 => undef,
+        application_server_name       => undef,
+        application_node_name         => undef,
+        corbaname_url                 => undef,
+        federated_context             => undef,
+        provider_url                  => 'example.com',
+        initial_context_factory       => 'PuppetInitialContext',
+        jndi_name                     => 'jndi_name',
+      }
+  DOC
+
+  # Our title_patterns method for mapping titles to namevars for supporting
+  # composite namevars.
+  def self.title_patterns
+    [
+      # corbaPuppetTest
+      [
+        %r{^([^:]+)$},
+        [
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:corbaPuppetTest
+      [
+        %r{^(.*):(.*)$},
+        [
+          [:profile_base],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:corbaPuppetTest
+      [
+        %r{^(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:cell:CELL_01:corbaPuppetTest
+      [
+        %r{^(.*):(.*):(cell):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:scope],
+          [:cell],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:cluster:CELL_01:TEST_CLUSTER_01:corbaPuppetTest
+      [
+        %r{^(.*):(.*):(cluster):(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:scope],
+          [:cell],
+          [:cluster],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:node:CELL_01:AppNode01:corbaPuppetTest
+      [
+        %r{^(.*):(.*):(node):(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:scope],
+          [:cell],
+          [:node_name],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:server:CELL_01:AppNode01:AppServer01:corbaPuppetTest
+      [
+        %r{^(.*):(.*):(server):(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:scope],
+          [:cell],
+          [:node_name],
+          [:server],
+          [:name],
+        ],
+      ],
+    ]
+  end
+
+  ensurable do
+    desc <<-EOT
+    Valid values: `present`, `absent`
+
+    Defaults to `true`.  Specifies whether this namespace binding should exist or not.
+    EOT
+
+    defaultto(:present)
+
+    newvalue(:present) do
+      provider.create
+    end
+
+    newvalue(:absent) do
+      provider.destroy
+    end
+  end
+
+  validate do
+    [:dmgr_profile, :name, :user, :node, :cell].each do |value|
+      raise ArgumentError, "Invalid #{value} #{self[value]}" unless value =~ %r{^[-0-9A-Za-z._]+$}
+    end
+
+    raise ArgumentError, "Invalid scope #{self[:scope]}: Must be cell, cluster, node, or server" unless self[:scope] =~ %r{^(cell|cluster|node|server)$}
+
+    raise ArgumentError, 'server is required when scope is server' if self[:server].nil? && self[:scope] == 'server'
+    raise ArgumentError, 'cell is a required attribute' if self[:cell].nil?
+    raise ArgumentError, 'node is required when scope is server, cell, or node' if self[:node_name].nil? && self[:scope] =~ %r{(server|cell|node)}
+    raise ArgumentError, 'cluster is required when scope is cluster' if self[:cluster].nil? && self[:scope] =~ %r{^cluster$}
+    raise("Invalid profile_base #{self[:profile_base]}") unless Pathname.new(self[:profile_base]).absolute?
+
+    if self[:profile].nil?
+      raise ArgumentError, 'profile is required' unless self[:dmgr_profile]
+      self[:profile] = self[:dmgr_profile]
+    end
+
+    # general namespace_binding validatione
+    raise ArgumentError, 'binding_type is invalid. Specify string, ejb, corba, or indirect' unless self[:binding_type] =~ %r{^(string|ejb|corba|indirect)$}
+    raise ArgumentError, 'name_in_name_space is required' if self[:name_in_name_space].nil?
+
+    # string binding_type validation
+    raise ArgumentError, 'string_to_bind is required when string binding_type' if self[:string_to_bind].nil? && self[:binding_type] == 'string'
+
+    # ejb binding_type validation
+    raise ArgumentError, 'ejb_jndi_name is required when ejb binding_type' if self[:ejb_jndi_name].nil? && self[:binding_type] == 'ejb'
+    raise ArgumentError, 'application_server_name is required when ejb binding_type' if self[:application_server_name].nil? && self[:binding_type] == 'ejb'
+
+    # corba binding_type validation
+    raise ArgumentError, 'corbaname_url is required when corba binding_type' if self[:corbaname_url].nil? && self[:binding_type] == 'corba'
+    raise ArgumentError, 'federated_context is required when corba binding_type' if self[:federated_context].nil? && self[:binding_type] == 'corba'
+
+    # indirect binding_type validation
+    raise ArgumentError, 'provider_url is required when indirect binding_type' if self[:provider_url].nil? && self[:binding_type] == 'indirect'
+    raise ArgumentError, 'jndi_name is required when indirect binding_type' if self[:jndi_name].nil? && self[:binding_type] == 'indirect'
+  end
+
+  newparam(:name) do
+    isnamevar
+    desc 'The name of the resource'
+  end
+
+  newparam(:binding_type) do
+    desc <<-EOT
+    Required. The binding type of the namespace.
+    EOT
+  end
+
+  newproperty(:name_in_name_space) do
+    desc <<-EOT
+    Required. The name of the name space relative to lookup name prefix.
+    EOT
+  end
+
+  newparam(:scope) do
+    isnamevar
+    desc <<-EOT
+    Required. The scope of namespace binding.
+    Valid values: cell, node, cluster, node group or server .
+    If scope is node, the cell and the node must be specified in their parameters.
+    If scope is cluster, the cell and the cluster must be specified in their parameters.
+    If scope is server, the cell, the node, and the server must be specified in their parameters.
+    EOT
+  end
+
+  newproperty(:string_to_bind) do
+    desc <<-EOT
+    The stringToBind value used in the StringNameSpaceBinding.
+    EOT
+  end
+
+  newproperty(:ejb_jndi_name) do
+    desc <<-EOT
+    The ejbJndiName value used in the EjbNameSpaceBinding.
+    EOT
+  end
+
+  newproperty(:application_server_name) do
+    desc <<-EOT
+    The applicationServerName value used in the EjbNameSpaceBinding.
+    EOT
+  end
+
+  newproperty(:application_node_name) do
+    desc <<-EOT
+    The applicationNodeName value used in the EjbNameSpaceBinding.
+    EOT
+  end
+
+  newproperty(:corbaname_url) do
+    desc <<-EOT
+    The corbanameUrl value used in the CORBAObjectNameSpaceBinding.
+    EOT
+  end
+
+  newproperty(:federated_context) do
+    desc <<-EOT
+    The federatedContext value used in the CORBAObjectNameSpaceBinding.
+    EOT
+
+    newvalues(:true, :false)
+
+    munge do |value|
+      value.to_s
+    end
+  end
+
+  newproperty(:provider_url) do
+    desc <<-EOT
+    The providerURL value used in the IndirectLookupNameSpaceBinding.
+    EOT
+  end
+
+  newproperty(:initial_context_factory) do
+    desc <<-EOT
+    The initialContextFactory value used in the IndirectLookupNameSpaceBinding.
+    EOT
+  end
+
+  newproperty(:jndi_name) do
+    desc <<-EOT
+    The jndiName value used in the IndirectLookupNameSpaceBinding.
+    EOT
+  end
+
+  newparam(:node) do
+    isnamevar
+    desc 'The name of the node to create this application server on'
+  end
+
+  newparam(:cluster) do
+    isnamevar
+    desc 'The name of the cluster to create this application server on'
+  end
+
+  newparam(:server) do
+    isnamevar
+    desc 'The name of the server to create this application server on'
+  end
+
+  newparam(:cell) do
+    isnamevar
+    desc 'The name of the cell to create this application server on'
+  end
+
+  newparam(:profile) do
+    desc "The profile to run 'wsadmin' under"
+  end
+
+  newparam(:dmgr_profile) do
+    isnamevar
+    defaultto { @resource[:profile] }
+    desc <<-EOT
+    The dmgr profile that this variable should be set under.  Basically, where
+    are we finding `wsadmin`
+
+    This is synonomous with the 'profile' parameter.
+
+    Example: dmgrProfile01
+    EOT
+  end
+
+  newparam(:profile_base) do
+    isnamevar
+    desc <<-EOT
+    The base directory that profiles are stored.
+    Basically, where can we find the 'dmgr_profile' so we can run 'wsadmin'
+    Example: /opt/IBM/WebSphere/AppServer/profiles"
+    EOT
+  end
+
+  newparam(:user) do
+    defaultto 'root'
+    desc "The user to run 'wsadmin' with"
+  end
+
+  newparam(:wsadmin_user) do
+    desc 'The username for wsadmin authentication'
+  end
+
+  newparam(:wsadmin_pass) do
+    desc 'The password for wsadmin authentication'
+  end
+end

--- a/lib/puppet/type/websphere_security_custom_property.rb
+++ b/lib/puppet/type/websphere_security_custom_property.rb
@@ -1,0 +1,162 @@
+require 'pathname'
+
+Puppet::Type.newtype(:websphere_security_custom_property) do
+  @doc = <<-DOC
+    @summary This manages a WebSphere Global Security Custom Property'
+    @example
+      websphere_security_custom_property { 'com.ibm.websphere.tls.disabledAlgorithms':
+        ensure                        => 'present',
+        dmgr_profile                  => 'PROFILE_DMGR_01',
+        profile_base                  => '/opt/IBM/WebSphere/AppServer/profiles',
+        user                          => 'webadmin',
+        cell                          => 'CELL_01',
+        node_name                     => 'DMGR_01',
+        property_value                => 'SSLv3,TLSv1,RC4,DH keySize < 768,MD5withRSA',
+      }
+  DOC
+
+  # Our title_patterns method for mapping titles to namevars for supporting
+  # composite namevars.
+  def self.title_patterns
+    [
+      # PuppetTest
+      [
+        %r{^([^:]+)$},
+        [
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PuppetTest
+      [
+        %r{^(.*):(.*)$},
+        [
+          [:profile_base],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:PuppetTest
+      [
+        %r{^(.*):(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:CELL_01:PuppetTest
+      [
+        %r{^(.*):(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:cell],
+          [:name],
+        ],
+      ],
+    ]
+  end
+
+  ensurable do
+    desc <<-EOT
+    Valid values: `present`, `absent`
+
+    Defaults to `true`.  Specifies whether this namespace binding should exist or not.
+    EOT
+
+    defaultto(:present)
+
+    newvalue(:present) do
+      provider.create
+    end
+
+    newvalue(:absent) do
+      provider.destroy
+    end
+  end
+
+  validate do
+    [:dmgr_profile, :name, :user, :node, :cell].each do |value|
+      raise ArgumentError, "Invalid #{value} #{self[value]}" unless value =~ %r{^[-0-9A-Za-z._]+$}
+    end
+
+    raise("Invalid profile_base #{self[:profile_base]}") unless Pathname.new(self[:profile_base]).absolute?
+
+    if self[:profile].nil?
+      raise ArgumentError, 'profile is required' unless self[:dmgr_profile]
+      self[:profile] = self[:dmgr_profile]
+    end
+  end
+
+  newparam(:name) do
+    isnamevar
+    desc 'The name of the resource'
+  end
+
+  newproperty(:property_value) do
+    desc <<-EOT
+    The value of the custom property.
+    EOT
+  end
+
+  newproperty(:description) do
+    desc <<-EOT
+    The description of the security custom property.
+    EOT
+  end
+
+  newparam(:node) do
+    desc 'The name of the node to create this application server on'
+  end
+
+  newparam(:cluster) do
+    desc 'The name of the cluster to create this application server on'
+  end
+
+  newparam(:server) do
+    desc 'The name of the server to create this application server on'
+  end
+
+  newparam(:cell) do
+    isnamevar
+    desc 'The name of the cell to create this application server on'
+  end
+
+  newparam(:profile) do
+    desc "The profile to run 'wsadmin' under"
+  end
+
+  newparam(:dmgr_profile) do
+    isnamevar
+    defaultto { @resource[:profile] }
+    desc <<-EOT
+    The dmgr profile that this variable should be set under.  Basically, where
+    are we finding `wsadmin`
+
+    This is synonomous with the 'profile' parameter.
+
+    Example: dmgrProfile01
+    EOT
+  end
+
+  newparam(:profile_base) do
+    isnamevar
+    desc <<-EOT
+    The base directory that profiles are stored.
+    Basically, where can we find the 'dmgr_profile' so we can run 'wsadmin'
+    Example: /opt/IBM/WebSphere/AppServer/profiles"
+    EOT
+  end
+
+  newparam(:user) do
+    defaultto 'root'
+    desc "The user to run 'wsadmin' with"
+  end
+
+  newparam(:wsadmin_user) do
+    desc 'The username for wsadmin authentication'
+  end
+
+  newparam(:wsadmin_pass) do
+    desc 'The password for wsadmin authentication'
+  end
+end

--- a/lib/puppet/type/websphere_shared_library.rb
+++ b/lib/puppet/type/websphere_shared_library.rb
@@ -1,0 +1,259 @@
+require 'pathname'
+
+Puppet::Type.newtype(:websphere_shared_library) do
+  @doc = <<-DOC
+    @summary This manages WebSphere Shared libraries.
+    @example
+      websphere_shared_library { 'exampleClusterSharedLibrary':
+        ensure                => 'present',
+        dmgr_profile          => 'PROFILE_DMGR_01',
+        profile_base          => '/opt/IBM/WebSphere/AppServer/profiles',
+        user                  => 'webadmin',
+        cell                  => 'CELL_01',
+        node_name             => 'AppNode01',
+        cluster               => 'TEST_CLUSTER',
+        scope                 => 'cluster',
+        class_path            => [
+          '/opt/IBM/shared_libraries/example',
+          '/tmp/shared_libraries/example',
+        ],
+        native_path           => [
+          '/tmp',
+        ],
+        isolated_class_loader => false,
+        description           => 'Created by Puppet',
+      }
+  DOC
+
+  # Our title_patterns method for mapping titles to namevars for supporting
+  # composite namevars.
+  def self.title_patterns
+    [
+      # PuppetTest
+      [
+        %r{^([^:]+)$},
+        [
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PuppetTest
+      [
+        %r{^(.*):(.*)$},
+        [
+          [:profile_base],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:PuppetTest
+      [
+        %r{^(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:cell:CELL_01:PuppetTest
+      [
+        %r{^(.*):(.*):(cell):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:scope],
+          [:cell],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:cluster:CELL_01:TEST_CLUSTER_01:PuppetTest
+      [
+        %r{^(.*):(.*):(cluster):(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:scope],
+          [:cell],
+          [:cluster],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:node:CELL_01:AppNode01:PuppetTest
+      [
+        %r{^(.*):(.*):(node):(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:scope],
+          [:cell],
+          [:node_name],
+          [:name],
+        ],
+      ],
+      # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:server:CELL_01:AppNode01:AppServer01:PuppetTest
+      [
+        %r{^(.*):(.*):(server):(.*):(.*):(.*)$},
+        [
+          [:profile_base],
+          [:dmgr_profile],
+          [:scope],
+          [:cell],
+          [:node_name],
+          [:server],
+          [:name],
+        ],
+      ],
+    ]
+  end
+
+  ensurable do
+    desc <<-EOT
+    Valid values: `present`, `absent`
+
+    Defaults to `true`.  Specifies whether this shared library should exist or not.
+    EOT
+
+    defaultto(:present)
+
+    newvalue(:present) do
+      provider.create
+    end
+
+    newvalue(:absent) do
+      provider.destroy
+    end
+  end
+
+  validate do
+    [:dmgr_profile, :name, :user, :node, :cell].each do |value|
+      raise ArgumentError, "Invalid #{value} #{self[value]}" unless value =~ %r{^[-0-9A-Za-z._]+$}
+    end
+
+    raise ArgumentError, "Invalid scope #{self[:scope]}: Must be cell, cluster, node, or server" unless self[:scope] =~ %r{^(cell|cluster|node|server)$}
+
+    raise ArgumentError, 'server is required when scope is server' if self[:server].nil? && self[:scope] == 'server'
+    raise ArgumentError, 'cell is a required attribute' if self[:cell].nil?
+    raise ArgumentError, 'node is required when scope is server, cell, or node' if self[:node_name].nil? && self[:scope] =~ %r{(server|cell|node)}
+    raise ArgumentError, 'cluster is required when scope is cluster' if self[:cluster].nil? && self[:scope] =~ %r{^cluster$}
+    raise("Invalid profile_base #{self[:profile_base]}") unless Pathname.new(self[:profile_base]).absolute?
+
+    if self[:profile].nil?
+      raise ArgumentError, 'profile is required' unless self[:dmgr_profile]
+      self[:profile] = self[:dmgr_profile]
+    end
+
+    raise ArgumentError, 'class_path is required' if self[:class_path].nil?
+  end
+
+  newparam(:name) do
+    isnamevar
+    desc 'The name of the resource'
+  end
+
+  newproperty(:class_path, array_matching: :all) do
+    desc <<-EOT
+    Required. Specifies a class path that contains the JAR files for this library.
+    Entries must not contain path separator characters (such as ';' or ':'). Class paths can contain variable (symbolic) names that can be substituted using a variable map.
+    EOT
+    # Override insync? to make sure we're comparing sorted arrays
+    def insync?(is)
+      is.sort == should.sort
+    end
+  end
+
+  newparam(:scope) do
+    isnamevar
+    desc <<-EOT
+    Required. The scope of namespace binding.
+    Valid values: cell, node, cluster, node group or server .
+    If scope is node, the cell and the node must be specified in their parameters.
+    If scope is cluster, the cell and the cluster must be specified in their parameters.
+    If scope is server, the cell, the node, and the server must be specified in their parameters.
+    EOT
+  end
+
+  newproperty(:native_path, array_matching: :all) do
+    desc <<-EOT
+    Specifies an optional path to any native libraries (DLL or SO files) required by this shared library.
+    EOT
+    # Override insync? to make sure we're comparing sorted arrays
+    def insync?(is)
+      is.sort == should.sort
+    end
+  end
+
+  newproperty(:description) do
+    desc <<-EOT
+    The description of the shared library.
+    EOT
+  end
+
+  newproperty(:isolated_class_loader) do
+    desc <<-EOT
+    Use an isolated class loader for this shared library.
+    EOT
+
+    newvalues(:true, :false)
+
+    munge do |value|
+      value.to_s
+    end
+  end
+
+  newparam(:node) do
+    isnamevar
+    desc 'The name of the node to create this application server on'
+  end
+
+  newparam(:cluster) do
+    isnamevar
+    desc 'The name of the cluster to create this application server on'
+  end
+
+  newparam(:server) do
+    isnamevar
+    desc 'The name of the server to create this application server on'
+  end
+
+  newparam(:cell) do
+    isnamevar
+    desc 'The name of the cell to create this application server on'
+  end
+
+  newparam(:profile) do
+    desc "The profile to run 'wsadmin' under"
+  end
+
+  newparam(:dmgr_profile) do
+    isnamevar
+    defaultto { @resource[:profile] }
+    desc <<-EOT
+    The dmgr profile that this variable should be set under.  Basically, where
+    are we finding `wsadmin`
+
+    This is synonomous with the 'profile' parameter.
+
+    Example: dmgrProfile01
+    EOT
+  end
+
+  newparam(:profile_base) do
+    isnamevar
+    desc <<-EOT
+    The base directory that profiles are stored.
+    Basically, where can we find the 'dmgr_profile' so we can run 'wsadmin'
+    Example: /opt/IBM/WebSphere/AppServer/profiles"
+    EOT
+  end
+
+  newparam(:user) do
+    defaultto 'root'
+    desc "The user to run 'wsadmin' with"
+  end
+
+  newparam(:wsadmin_user) do
+    desc 'The username for wsadmin authentication'
+  end
+
+  newparam(:wsadmin_pass) do
+    desc 'The password for wsadmin authentication'
+  end
+end


### PR DESCRIPTION
Adds a few new resources with composite namevars. This will allow a user to specify a resource with the same name across websphere instances, clusters, nodes, servers, etc on the same server.

- Websphere_jdbc_datasource_jaas_auth_data
- Websphere_jdbc_datasource_custom_property
- Websphere_jvm_custom_property
- Websphere_namespace_bindings
- Websphere_security_custom_property
- Websphere_shared_library

Modifies a few existing resources to increase puppet run speed. Previously within the exists? method, we would reference a call to wsadmin. wsadmin spins up a jython jvm to execute a command. From my experience, you can see the wsadmin process taking 6 to 12 seconds to spin up. When a user has multiple DMGR profiles on a single server, this time is costly and can take a Puppet run with 0 corrective and intentional changes over 40 minutes. To address this issue, we parse the XML configuration files instead.

Since I'm modifying the existing composite namevar implementation for websphere_variable it is considered a breaking change to any users using the previous composite namevars implementation. 