### PR TITLE
Fix was files ownership

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -176,8 +176,8 @@ define websphere_application_server::instance (
 
   file { $_profile_base:
     ensure  => 'directory',
-    owner   => $user,
-    group   => $group,
+    owner   => $::websphere_application_server::user,
+    group   => $::websphere_application_server::group,
     require => Ibm_pkg[$title],
   }
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -174,6 +174,9 @@ define websphere_application_server::instance (
     user                => $user,
   }
 
+  # Here we reference the actual user we want to own this as we likely need to install this
+  # as root - the user passed to this defined type. If we don't do this, there are further unnecessary 
+  # chowns run to tidy this up.
   file { $_profile_base:
     ensure  => 'directory',
     owner   => $::websphere_application_server::user,


### PR DESCRIPTION
This allows the installation and management of the WAS suite as root, but allows the change of the ownership of the WAS profile directory to a low-permission user/group  (e.g wasadmin/wasgroup)

The functionality of this type does not change if the installation user/group is the same as the WAS admin user/group.
