### PR TITLE
Fix websphere variable type

### DIFF
--- a/lib/puppet/provider/websphere_variable/wsadmin.rb
+++ b/lib/puppet/provider/websphere_variable/wsadmin.rb
@@ -24,11 +24,11 @@ Puppet::Type.type(:websphere_variable).provide(:wsadmin, parent: Puppet::Provide
     when 'node'
       query = "/Cell:#{resource[:cell]}/Node:#{resource[:node_name]}"
       mod   = "cells/#{resource[:cell]}/nodes/#{resource[:node_name]}"
-      file << "/config/cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/variables.xml"
+      file += "/config/cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/variables.xml"
     when 'server'
       query = "/Cell:#{resource[:cell]}/Node:#{resource[:node_name]}/Server:#{resource[:server]}"
       mod   = "cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/servers/#{resource[:server]}"
-      file << "/config/cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/servers/#{resource[:server]}/variables.xml"
+      file += "/config/cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/servers/#{resource[:server]}/variables.xml"
     else
       raise Puppet::Error, "Unknown scope: #{resource[:scope]}"
     end

--- a/lib/puppet/type/websphere_variable.rb
+++ b/lib/puppet/type/websphere_variable.rb
@@ -112,7 +112,7 @@ Puppet::Type.newtype(:websphere_variable) do
       self[:profile] = self[:dmgr_profile]
     end
 
-    [:variable, :server, :cell, :node, :cluster, :profile, :user].each do |value|
+    [:variable, :server, :cell, :node_name, :cluster, :profile, :user].each do |value|
       raise ArgumentError, "Invalid #{value} #{self[:value]}" unless %r{^[-0-9A-Za-z._]+$}.match?(value)
     end
   end
@@ -151,7 +151,7 @@ Puppet::Type.newtype(:websphere_variable) do
     desc 'The cell that this variable should be set in'
   end
 
-  newparam(:node) do
+  newparam(:node_name) do
     isnamevar
     desc 'The node that this variable should be set under'
   end


### PR DESCRIPTION
This pull request fixes the following issues in the Websphere variable type:

1. bug caused by frozen vars in Ruby code
2. inconsistent naming of variables: node vs node_name