### PR TITLE
fix bug by referencing node_name instead of node

### DIFF
--- a/lib/puppet/type/websphere_jvm_custom_property.rb
+++ b/lib/puppet/type/websphere_jvm_custom_property.rb
@@ -105,7 +105,7 @@ Puppet::Type.newtype(:websphere_jvm_custom_property) do
   end
 
   validate do
-    [:dmgr_profile, :name, :user, :node, :cell].each do |value|
+    [:dmgr_profile, :name, :user, :node_name, :cell].each do |value|
       raise ArgumentError, "Invalid #{value} #{self[value]}" unless %r{^[-0-9A-Za-z._]+$}.match?(value)
     end
 
@@ -148,7 +148,7 @@ Puppet::Type.newtype(:websphere_jvm_custom_property) do
     EOT
   end
 
-  newparam(:node) do
+  newparam(:node_name) do
     isnamevar
     desc 'The name of the node to create this application server on'
   end

--- a/lib/puppet/type/websphere_jvm_custom_property.rb
+++ b/lib/puppet/type/websphere_jvm_custom_property.rb
@@ -90,7 +90,7 @@ Puppet::Type.newtype(:websphere_jvm_custom_property) do
     desc <<-EOT
     Valid values: `present`, `absent`
 
-    Defaults to `true`.  Specifies whether this custom property should exist or not.
+    Defaults to `present`.  Specifies whether this custom property should exist or not.
     EOT
 
     defaultto(:present)
@@ -138,33 +138,33 @@ Puppet::Type.newtype(:websphere_jvm_custom_property) do
 
   newproperty(:description) do
     desc <<-EOT
-    The description of the datasource custom property.
+    The description of the JVM custom property.
     EOT
   end
 
   newproperty(:property_value) do
     desc <<-EOT
-    The value of the datasource custom property.
+    The value of the JVM custom property.
     EOT
   end
 
   newparam(:node_name) do
     isnamevar
-    desc 'The name of the node to create this application server on'
+    desc 'The name of the node to create this JVM custom property on'
   end
 
   newparam(:cluster) do
-    desc 'The name of the cluster to create this application server on'
+    desc 'The name of the cluster to create this JVM custom property on'
   end
 
   newparam(:server) do
     isnamevar
-    desc 'The name of the server to create this application server on'
+    desc 'The name of the server to create this JVM custom property on'
   end
 
   newparam(:cell) do
     isnamevar
-    desc 'The name of the cell to create this application server on'
+    desc 'The name of the cell to create this JVM custom property on'
   end
 
   newparam(:profile) do


### PR DESCRIPTION
This pull request fixes a bug in JVM Custom Property type caused by inconsistent variable naming: provider is referencing `node_name` instead of `node` 