### PR TITLE
Fix complaints about title patterns using procs being not supported

### DIFF
--- a/lib/puppet/type/websphere_jvm_log.rb
+++ b/lib/puppet/type/websphere_jvm_log.rb
@@ -20,36 +20,35 @@ Puppet::Type.newtype(:websphere_jvm_log) do
   end
 
   def self.title_patterns
-    identity = ->(x) { x }
     [
       [
         %r{^(.*):(.*):(.*):(.*)$},
         [
-          [:cell, identity],
-          [:node_name, identity],
-          [:scope, identity],
-          [:server, identity],
+          [:cell],
+          [:node_name],
+          [:scope],
+          [:server],
         ],
       ],
       [
         %r{^(.*):(.*):(.*)$},
         [
-          [:cell, identity],
-          [:node_name, identity],
-          [:scope, identity],
+          [:cell],
+          [:node_name],
+          [:scope],
         ],
       ],
       [
         %r{^(.*):(.*)$},
         [
-          [:cell, identity],
-          [:node_name, identity],
+          [:cell],
+          [:node_name],
         ],
       ],
       [
         %r{^(.*)$},
         [
-          [:cell, identity],
+          [:cell],
         ],
       ],
     ]

--- a/lib/puppet/type/websphere_sdk.rb
+++ b/lib/puppet/type/websphere_sdk.rb
@@ -12,19 +12,18 @@ Puppet::Type.newtype(:websphere_sdk) do
   end
 
   def self.title_patterns
-    identity = ->(x) { x }
     [
       [
         %r{^(.*)_(.*)$},
         [
-          [:profile, identity],
-          [:sdkname, identity],
+          [:profile],
+          [:sdkname],
         ],
       ],
       [
         %r{^(.*)$},
         [
-          [:sdkname, identity],
+          [:sdkname],
         ],
       ],
     ]


### PR DESCRIPTION
This fixes an issue about title patterns using procs. This is no longer supported so they have to come out.

The following types are affected:

- `websphere_jvm_log`
- `websphere_sdk`