### PR TITLE
Fix generic jvm args

### DIFF
--- a/lib/puppet/provider/websphere_cluster_member/wsadmin.rb
+++ b/lib/puppet/provider/websphere_cluster_member/wsadmin.rb
@@ -58,6 +58,7 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
     AdminTask.deleteClusterMember(['-clusterName', '#{resource[:cluster]}', '-memberNode', '#{resource[:node_name]}', '-memberName', '#{resource[:name]}'])
     AdminConfig.save()
     END
+    debug "Running #{cmd}"
     wsadmin(file: cmd, user: resource[:user])
   end
 
@@ -81,9 +82,10 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
   def runas_user=(_value)
     cmd = <<-END.unindent
     the_id = AdminConfig.list('ProcessExecution', '(cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/servers/#{resource[:name]}|server.xml)')
-    AdminConfig.modify(the_id, [['runAsUser', #{resource[:runas_user]}]])
+    AdminConfig.modify(the_id, [['runAsUser', '#{resource[:runas_user]}']])
     AdminConfig.save()
     END
+    debug "Running #{cmd}"
     wsadmin(file: cmd, user: resource[:user])
   end
 
@@ -94,9 +96,10 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
   def runas_group=(_value)
     cmd = <<-END.unindent
     the_id = AdminConfig.list('ProcessExecution', '(cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/servers/#{resource[:name]}|server.xml)')
-    AdminConfig.modify(the_id, [['runAsGroup', #{resource[:runas_group]}]])
+    AdminConfig.modify(the_id, [['runAsGroup', '#{resource[:runas_group]}']])
     AdminConfig.save()
     END
+    debug "Running #{cmd}"
     wsadmin(file: cmd, user: resource[:user])
   end
 
@@ -110,9 +113,10 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
   def umask=(_value)
     cmd = <<-END.unindent
     the_id = AdminConfig.list('ProcessExecution', '(cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/servers/#{resource[:name]}|server.xml)')
-    AdminConfig.modify(the_id, [['umask', #{resource[:umask]}]])
+    AdminConfig.modify(the_id, [['umask', '#{resource[:umask]}']])
     AdminConfig.save()
     END
+    debug "Running #{cmd}"
     wsadmin(file: cmd, user: resource[:user])
   end
 
@@ -234,6 +238,7 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
     AdminConfig.modify(the_id, [['totalTranLifetimeTimeout', #{resource[:total_transaction_timeout]}]])
     AdminConfig.save()
     END
+    debug "Running #{cmd}"
     wsadmin(file: cmd, user: resource[:user])
   end
 
@@ -251,6 +256,7 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
     AdminConfig.modify(the_id, [['clientInactivityTimeout', #{resource[:client_inactivity_timeout]}]])
     AdminConfig.save()
     END
+    debug "Running #{cmd}"
     wsadmin(file: cmd, user: resource[:user])
   end
 
@@ -274,6 +280,7 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
       AdminConfig.modify(tpWebContainer, [['minimumSize', #{resource[:threadpool_webcontainer_min_size]}]])
       AdminConfig.save()
     END
+    debug "Running #{cmd}"
     wsadmin(file: cmd, user: resource[:user])
   end
 
@@ -297,6 +304,7 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
       AdminConfig.modify(tpWebContainer, [['maximumSize', #{resource[:threadpool_webcontainer_max_size]}]])
       AdminConfig.save()
     END
+    debug "Running #{cmd}"
     wsadmin(file: cmd, user: resource[:user])
     refresh
   end

--- a/lib/puppet/provider/websphere_cluster_member/wsadmin.rb
+++ b/lib/puppet/provider/websphere_cluster_member/wsadmin.rb
@@ -67,7 +67,7 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
     cmd = "\"AdminTask.setJVMProperties('[-nodeName " + resource[:node_name]
     cmd += ' -serverName ' + resource[:name] + ' -'
     cmd += name + ' '
-    cmd += value
+    cmd += "\'" + value + "\'"
     cmd += "]')\""
     wsadmin(command: cmd, user: resource[:user])
   end

--- a/lib/puppet/provider/websphere_cluster_member/wsadmin.rb
+++ b/lib/puppet/provider/websphere_cluster_member/wsadmin.rb
@@ -58,7 +58,7 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
     AdminTask.deleteClusterMember(['-clusterName', '#{resource[:cluster]}', '-memberNode', '#{resource[:node_name]}', '-memberName', '#{resource[:name]}'])
     AdminConfig.save()
     END
-    wsadmin(command: cmd, user: resource[:user])
+    wsadmin(file: cmd, user: resource[:user])
   end
 
   ## Helper method for modifying JVM properties
@@ -67,7 +67,7 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
     AdminTask.setJVMProperties(['-nodeName', '#{resource[:node_name]}', '-serverName', '#{resource[:name]}', '-#{name}', '#{value}'])
     AdminConfig.save()
     END
-    wsadmin(command: cmd, user: resource[:user])
+    wsadmin(file: cmd, user: resource[:user])
   end
 
   def runas_user
@@ -80,7 +80,7 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
     AdminConfig.modify(the_id, [['runAsUser', #{resource[:runas_user]}]])
     AdminConfig.save()
     END
-    wsadmin(command: cmd, user: resource[:user])
+    wsadmin(file: cmd, user: resource[:user])
   end
 
   def runas_group
@@ -93,7 +93,7 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
     AdminConfig.modify(the_id, [['runAsGroup', #{resource[:runas_group]}]])
     AdminConfig.save()
     END
-    wsadmin(command: cmd, user: resource[:user])
+    wsadmin(file: cmd, user: resource[:user])
   end
 
   def umask
@@ -109,7 +109,7 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
     AdminConfig.modify(the_id, [['umask', #{resource[:umask]}]])
     AdminConfig.save()
     END
-    wsadmin(command: cmd, user: resource[:user])
+    wsadmin(file: cmd, user: resource[:user])
   end
 
   def jvm_maximum_heap_size
@@ -230,7 +230,7 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
     AdminConfig.modify(the_id, [['totalTranLifetimeTimeout', #{resource[:total_transaction_timeout]}]])
     AdminConfig.save()
     END
-    wsadmin(command: cmd, user: resource[:user])
+    wsadmin(file: cmd, user: resource[:user])
   end
 
   def client_inactivity_timeout
@@ -247,7 +247,7 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
     AdminConfig.modify(the_id, [['clientInactivityTimeout', #{resource[:client_inactivity_timeout]}]])
     AdminConfig.save()
     END
-    wsadmin(command: cmd, user: resource[:user])
+    wsadmin(file: cmd, user: resource[:user])
   end
 
   def threadpool_webcontainer_min_size

--- a/lib/puppet/provider/websphere_cluster_member/wsadmin.rb
+++ b/lib/puppet/provider/websphere_cluster_member/wsadmin.rb
@@ -42,7 +42,7 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
       msg = "Websphere_cluster_member[#{resource[:name]}]: Failed to "\
                + 'add cluster member. Make sure the node service is running '\
                + "on the remote server. Output: #{result}"
-      raise Puppet::Error, "Failed to add cluster member. Run with --debug for details. #{msg}"
+      raise Puppet::Error, "Failed to add cluster member. Run with --debug --trace for details. #{msg}"
     end
     resource.class.validproperties.each do |property|
       value = resource.should(property)
@@ -54,21 +54,19 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
   end
 
   def destroy
-    cmd = "\"AdminTask.deleteClusterMember('[-clusterName "
-    cmd += resource[:cluster] + ' -memberNode ' + resource[:node_name]
-    cmd += ' -memberName ' + resource[:name]
-    cmd += "]')\""
-
+    cmd = <<-END.unindent
+    AdminTask.deleteClusterMember(['-clusterName', '#{resource[:cluster]}', '-memberNode', '#{resource[:node_name]}', '-memberName', '#{resource[:name]}'])
+    AdminConfig.save()
+    END
     wsadmin(command: cmd, user: resource[:user])
   end
 
   ## Helper method for modifying JVM properties
   def jvm_property(name, value)
-    cmd = "\"AdminTask.setJVMProperties('[-nodeName " + resource[:node_name]
-    cmd += ' -serverName ' + resource[:name] + ' -'
-    cmd += name + ' '
-    cmd += "\'" + value + "\'"
-    cmd += "]')\""
+    cmd = <<-END.unindent
+    AdminTask.setJVMProperties(['-nodeName', '#{resource[:node_name]}', '-serverName', '#{resource[:name]}', '-#{name}', '#{value}'])
+    AdminConfig.save()
+    END
     wsadmin(command: cmd, user: resource[:user])
   end
 
@@ -77,13 +75,11 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
   end
 
   def runas_user=(_value)
-    cmd = "\"the_id = AdminConfig.list('ProcessExecution','(cells/"
-    cmd += resource[:cell]
-    cmd += '/nodes/' + resource[:node_name] + '/servers/'
-    cmd += resource[:name] + "|server.xml)');"
-    cmd += "AdminConfig.modify(the_id, [['runAsUser', '" + resource[:runas_user]
-    cmd += "']])\""
-
+    cmd = <<-END.unindent
+    the_id = AdminConfig.list('ProcessExecution', '(cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/servers/#{resource[:name]}|server.xml)')
+    AdminConfig.modify(the_id, [['runAsUser', #{resource[:runas_user]}]])
+    AdminConfig.save()
+    END
     wsadmin(command: cmd, user: resource[:user])
   end
 
@@ -92,13 +88,11 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
   end
 
   def runas_group=(_value)
-    cmd = "\"the_id = AdminConfig.list('ProcessExecution','(cells/"
-    cmd += resource[:cell]
-    cmd += '/nodes/' + resource[:node_name] + '/servers/'
-    cmd += resource[:name] + "|server.xml)');"
-    cmd += "AdminConfig.modify(the_id, [['runAsGroup', '" + resource[:runas_group]
-    cmd += "']])\""
-
+    cmd = <<-END.unindent
+    the_id = AdminConfig.list('ProcessExecution', '(cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/servers/#{resource[:name]}|server.xml)')
+    AdminConfig.modify(the_id, [['runAsGroup', #{resource[:runas_group]}]])
+    AdminConfig.save()
+    END
     wsadmin(command: cmd, user: resource[:user])
   end
 
@@ -110,13 +104,11 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
   end
 
   def umask=(_value)
-    cmd = "\"the_id = AdminConfig.list('ProcessExecution','(cells/"
-    cmd += resource[:cell]
-    cmd += '/nodes/' + resource[:node_name] + '/servers/'
-    cmd += resource[:name] + "|server.xml)');"
-    cmd += "AdminConfig.modify(the_id, [['umask', '" + resource[:umask]
-    cmd += "']])\""
-
+    cmd = <<-END.unindent
+    the_id = AdminConfig.list('ProcessExecution', '(cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/servers/#{resource[:name]}|server.xml)')
+    AdminConfig.modify(the_id, [['umask', #{resource[:umask]}]])
+    AdminConfig.save()
+    END
     wsadmin(command: cmd, user: resource[:user])
   end
 
@@ -233,14 +225,11 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
   end
 
   def total_transaction_timeout=(_value)
-    cmd = "\"the_id = AdminConfig.list('TransactionService','(cells/"
-    cmd += resource[:cell]
-    cmd += '/nodes/' + resource[:node_name] + '/servers/'
-    cmd += resource[:name] + "|server.xml)');"
-    cmd += 'AdminConfig.modify(the_id, \'[[totalTranLifetimeTimeout "'
-    cmd += resource[:total_transaction_timeout]
-    cmd += '"]]\')"'
-
+    cmd = <<-END.unindent
+    the_id = AdminConfig.list('TransactionService', '(cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/servers/#{resource[:name]}|server.xml)')
+    AdminConfig.modify(the_id, [['totalTranLifetimeTimeout', #{resource[:total_transaction_timeout]}]])
+    AdminConfig.save()
+    END
     wsadmin(command: cmd, user: resource[:user])
   end
 
@@ -253,14 +242,11 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
   end
 
   def client_inactivity_timeout=(_value)
-    cmd = "\"the_id = AdminConfig.list('TransactionService','(cells/"
-    cmd += resource[:cell]
-    cmd += '/nodes/' + resource[:node_name] + '/servers/'
-    cmd += resource[:name] + "|server.xml)');"
-    cmd += 'AdminConfig.modify(the_id, \'[[clientInactivityTimeout "'
-    cmd += resource[:client_inactivity_timeout]
-    cmd += '"]]\')"'
-
+    cmd = <<-END.unindent
+    the_id = AdminConfig.list('TransactionService', '(cells/#{resource[:cell]}/nodes/#{resource[:node_name]}/servers/#{resource[:name]}|server.xml)')
+    AdminConfig.modify(the_id, [['clientInactivityTimeout', #{resource[:client_inactivity_timeout]}]])
+    AdminConfig.save()
+    END
     wsadmin(command: cmd, user: resource[:user])
   end
 

--- a/lib/puppet/provider/websphere_cluster_member/wsadmin.rb
+++ b/lib/puppet/provider/websphere_cluster_member/wsadmin.rb
@@ -62,11 +62,15 @@ Puppet::Type.type(:websphere_cluster_member).provide(:wsadmin, parent: Puppet::P
   end
 
   ## Helper method for modifying JVM properties
+  ## This breaks horribly if we are using a Jython List instead of a Jython String. This is because if the arguments contain dashes
+  ## they are interpreted as options to Jython, not values to the previous option - so you can't set JVM arguments which contain -Dxxxx
   def jvm_property(name, value)
     cmd = <<-END.unindent
-    AdminTask.setJVMProperties(['-nodeName', '#{resource[:node_name]}', '-serverName', '#{resource[:name]}', '-#{name}', '#{value}'])
+    AdminTask.setJVMProperties('[-nodeName "#{resource[:node_name]}" -serverName "#{resource[:name]}" -#{name} "#{value}"]')
     AdminConfig.save()
     END
+
+    debug "Running command: #{cmd}"
     wsadmin(file: cmd, user: resource[:user])
   end
 


### PR DESCRIPTION
This fixes bugs in the JVM Args type whereby multiple space-separated JVM arguments fail to be added to WAS.

This also:

- changes to a proper Jython code fragment instead of an assembled ruby string.
- adds further debug messages