### PR TITLE
Fix shared library changes

### DIFF
--- a/lib/puppet/provider/websphere_shared_library/wsadmin.rb
+++ b/lib/puppet/provider/websphere_shared_library/wsadmin.rb
@@ -171,6 +171,11 @@ EOS
     return if @property_hash.empty?
     cmd = <<-EOS
 id = AdminConfig.getid(\"#{scope('query')}Library:#{resource[:name]}\")
+
+# The modify command appends the specified unique classPath or nativePath values to the existing values.
+# To completely replace the values, we must first remove the path attributes using the unsetAttributes command.
+AdminConfig.unsetAttributes(id, '["classPath" "nativePath"]')
+
 AdminConfig.modify(id, #{modified_attributes_list_list})
 AdminConfig.save()
 EOS

--- a/lib/puppet/type/websphere_shared_library.rb
+++ b/lib/puppet/type/websphere_shared_library.rb
@@ -92,7 +92,7 @@ Puppet::Type.newtype(:websphere_shared_library) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:server:CELL_01:AppNode01:AppServer01:PuppetTest
       [
-        %r{^(.*):(.*):(server):(.*):(.*):(.*)$},
+        %r{^(.*):(.*):(server):(.*):(.*):(.*):(.*)$},
         [
           [:profile_base],
           [:dmgr_profile],

--- a/lib/puppet/type/websphere_shared_library.rb
+++ b/lib/puppet/type/websphere_shared_library.rb
@@ -92,7 +92,7 @@ Puppet::Type.newtype(:websphere_shared_library) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:server:CELL_01:AppNode01:AppServer01:PuppetTest
       [
-        %r{^(.*):(.*):(server):(.*):(.*):(.*):(.*)$},
+        %r{^(.*):(.*):(server):(.*):(.*):(.*)$},
         [
           [:profile_base],
           [:dmgr_profile],


### PR DESCRIPTION
This fixes a bug in the Jython code whereby replacements for the shared library paths are added not replaced.

