### PR TITLE
Fix security custom property namevar

### DIFF
--- a/lib/puppet/provider/websphere_security_custom_property/wsadmin.rb
+++ b/lib/puppet/provider/websphere_security_custom_property/wsadmin.rb
@@ -105,6 +105,8 @@ EOS
     result = wsadmin(file: cmd, user: resource[:user])
     debug result
 
-    sync_node
+    # Because this deals with global settings - we don't always have a node name to sync to
+    # Do this, only when we have a node name passed as a param.
+    sync_node unless resource[:node].nil?
   end
 end

--- a/lib/puppet/type/websphere_security_custom_property.rb
+++ b/lib/puppet/type/websphere_security_custom_property.rb
@@ -38,7 +38,7 @@ Puppet::Type.newtype(:websphere_security_custom_property) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:PuppetTest
       [
-        %r{^(.*):(.*):(.*):(.*)$},
+        %r{^(.*):(.*):(.*)$},
         [
           [:profile_base],
           [:dmgr_profile],

--- a/lib/puppet/type/websphere_security_custom_property.rb
+++ b/lib/puppet/type/websphere_security_custom_property.rb
@@ -30,7 +30,7 @@ Puppet::Type.newtype(:websphere_security_custom_property) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PuppetTest
       [
-        %r{^(.*):(.*)$},
+        %r{^([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:name],
@@ -38,7 +38,7 @@ Puppet::Type.newtype(:websphere_security_custom_property) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:PuppetTest
       [
-        %r{^(.*):(.*):(.*)$},
+        %r{^([^:]+):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],
@@ -47,7 +47,7 @@ Puppet::Type.newtype(:websphere_security_custom_property) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:CELL_01:PuppetTest
       [
-        %r{^(.*):(.*):(.*):(.*)$},
+        %r{^([^:]+):([^:]+):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],


### PR DESCRIPTION
This applies fixes to the security custom properties:

1. fix spurious 3rd namevar combo
2. exclude `:` from the list of valid characters in the namer matching regex
3. call `syncnode()` only when we have a node name