### PR TITLE
Multiple fixes for NSBinding, Shared Library and Websphere Variable

### DIFF
--- a/lib/puppet/type/websphere_namespace_binding.rb
+++ b/lib/puppet/type/websphere_namespace_binding.rb
@@ -157,7 +157,7 @@ Puppet::Type.newtype(:websphere_namespace_binding) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:server:CELL_01:AppNode01:AppServer01:corbaPuppetTest
       [
-        %r{^([^:]+):([^:]+):(server):([^:]+):([^:]+):([^:]+)$},
+        %r{^([^:]+):([^:]+):(server):([^:]+):([^:]+):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],
@@ -346,7 +346,7 @@ Puppet::Type.newtype(:websphere_namespace_binding) do
     The dmgr profile that this variable should be set under.  Basically, where
     are we finding `wsadmin`
 
-    This is synonomous with the 'profile' parameter.
+    This is synonymous with the 'profile' parameter.
 
     Example: dmgrProfile01
     EOT

--- a/lib/puppet/type/websphere_namespace_binding.rb
+++ b/lib/puppet/type/websphere_namespace_binding.rb
@@ -105,7 +105,7 @@ Puppet::Type.newtype(:websphere_namespace_binding) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:corbaPuppetTest
       [
-        %r{^(.*):(.*)$},
+        %r{^([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:name],
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:websphere_namespace_binding) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:corbaPuppetTest
       [
-        %r{^(.*):(.*):(.*)$},
+        %r{^([^:]+):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],
@@ -122,7 +122,7 @@ Puppet::Type.newtype(:websphere_namespace_binding) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:cell:CELL_01:corbaPuppetTest
       [
-        %r{^(.*):(.*):(cell):(.*):(.*)$},
+        %r{^([^:]+):([^:]+):(cell):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],
@@ -133,7 +133,7 @@ Puppet::Type.newtype(:websphere_namespace_binding) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:cluster:CELL_01:TEST_CLUSTER_01:corbaPuppetTest
       [
-        %r{^(.*):(.*):(cluster):(.*):(.*):(.*)$},
+        %r{^([^:]+):([^:]+):(cluster):([^:]+):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],
@@ -145,7 +145,7 @@ Puppet::Type.newtype(:websphere_namespace_binding) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:node:CELL_01:AppNode01:corbaPuppetTest
       [
-        %r{^(.*):(.*):(node):(.*):(.*):(.*)$},
+        %r{^([^:]+):([^:]+):(node):([^:]+):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],
@@ -157,7 +157,7 @@ Puppet::Type.newtype(:websphere_namespace_binding) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:server:CELL_01:AppNode01:AppServer01:corbaPuppetTest
       [
-        %r{^(.*):(.*):(server):(.*):(.*):(.*)$},
+        %r{^([^:]+):([^:]+):(server):([^:]+):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],
@@ -190,7 +190,7 @@ Puppet::Type.newtype(:websphere_namespace_binding) do
   end
 
   validate do
-    [:dmgr_profile, :name, :user, :node, :cell].each do |value|
+    [:dmgr_profile, :name, :user, :node_name, :cell].each do |value|
       raise ArgumentError, "Invalid #{value} #{self[value]}" unless %r{^[-0-9A-Za-z._]+$}.match?(value)
     end
 
@@ -198,7 +198,7 @@ Puppet::Type.newtype(:websphere_namespace_binding) do
 
     raise ArgumentError, 'server is required when scope is server' if self[:server].nil? && self[:scope] == 'server'
     raise ArgumentError, 'cell is a required attribute' if self[:cell].nil?
-    raise ArgumentError, 'node is required when scope is server, cell, or node' if self[:node_name].nil? && self[:scope] =~ %r{(server|cell|node)}
+    raise ArgumentError, 'node is required when scope is server, cell, or node' if self[:node_name].nil? && self[:scope] =~ %r{^(server|node)$}
     raise ArgumentError, 'cluster is required when scope is cluster' if self[:cluster].nil? && self[:scope] =~ %r{^cluster$}
     raise("Invalid profile_base #{self[:profile_base]}") unless Pathname.new(self[:profile_base]).absolute?
 
@@ -315,7 +315,7 @@ Puppet::Type.newtype(:websphere_namespace_binding) do
     EOT
   end
 
-  newparam(:node) do
+  newparam(:node_name) do
     isnamevar
     desc 'The name of the node to create this application server on'
   end

--- a/lib/puppet/type/websphere_namespace_binding.rb
+++ b/lib/puppet/type/websphere_namespace_binding.rb
@@ -198,7 +198,7 @@ Puppet::Type.newtype(:websphere_namespace_binding) do
 
     raise ArgumentError, 'server is required when scope is server' if self[:server].nil? && self[:scope] == 'server'
     raise ArgumentError, 'cell is a required attribute' if self[:cell].nil?
-    raise ArgumentError, 'node is required when scope is server, cell, or node' if self[:node_name].nil? && self[:scope] =~ %r{^(server|node)$}
+    raise ArgumentError, 'node_name is required when scope is server or node' if self[:node_name].nil? && self[:scope] =~ %r{^(server|node)$}
     raise ArgumentError, 'cluster is required when scope is cluster' if self[:cluster].nil? && self[:scope] =~ %r{^cluster$}
     raise("Invalid profile_base #{self[:profile_base]}") unless Pathname.new(self[:profile_base]).absolute?
 

--- a/lib/puppet/type/websphere_shared_library.rb
+++ b/lib/puppet/type/websphere_shared_library.rb
@@ -40,7 +40,7 @@ Puppet::Type.newtype(:websphere_shared_library) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PuppetTest
       [
-        %r{^(.*):(.*)$},
+        %r{^([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:name],
@@ -48,7 +48,7 @@ Puppet::Type.newtype(:websphere_shared_library) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:PuppetTest
       [
-        %r{^(.*):(.*):(.*)$},
+        %r{^([^:]+):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],
@@ -57,7 +57,7 @@ Puppet::Type.newtype(:websphere_shared_library) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:cell:CELL_01:PuppetTest
       [
-        %r{^(.*):(.*):(cell):(.*):(.*)$},
+        %r{^([^:]+):([^:]+):(cell):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],
@@ -68,7 +68,7 @@ Puppet::Type.newtype(:websphere_shared_library) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:cluster:CELL_01:TEST_CLUSTER_01:PuppetTest
       [
-        %r{^(.*):(.*):(cluster):(.*):(.*):(.*)$},
+        %r{^([^:]+):([^:]+):(cluster):([^:]+):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],
@@ -80,7 +80,7 @@ Puppet::Type.newtype(:websphere_shared_library) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:node:CELL_01:AppNode01:PuppetTest
       [
-        %r{^(.*):(.*):(node):(.*):(.*):(.*)$},
+        %r{^([^:]+):([^:]+):(node):([^:]+):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],
@@ -92,7 +92,7 @@ Puppet::Type.newtype(:websphere_shared_library) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:server:CELL_01:AppNode01:AppServer01:PuppetTest
       [
-        %r{^(.*):(.*):(server):(.*):(.*):(.*)$},
+        %r{^([^:]+):([^:]+):(server):([^:]+):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],
@@ -125,7 +125,7 @@ Puppet::Type.newtype(:websphere_shared_library) do
   end
 
   validate do
-    [:dmgr_profile, :name, :user, :node, :cell].each do |value|
+    [:dmgr_profile, :name, :user, :node_name, :cell].each do |value|
       raise ArgumentError, "Invalid #{value} #{self[value]}" unless %r{^[-0-9A-Za-z._]+$}.match?(value)
     end
 
@@ -133,7 +133,7 @@ Puppet::Type.newtype(:websphere_shared_library) do
 
     raise ArgumentError, 'server is required when scope is server' if self[:server].nil? && self[:scope] == 'server'
     raise ArgumentError, 'cell is a required attribute' if self[:cell].nil?
-    raise ArgumentError, 'node is required when scope is server, cell, or node' if self[:node_name].nil? && self[:scope] =~ %r{(server|cell|node)}
+    raise ArgumentError, 'node_name is required when scope is server or node' if self[:node_name].nil? && self[:scope] =~ %r{(server|node)}
     raise ArgumentError, 'cluster is required when scope is cluster' if self[:cluster].nil? && self[:scope] =~ %r{^cluster$}
     raise("Invalid profile_base #{self[:profile_base]}") unless Pathname.new(self[:profile_base]).absolute?
 
@@ -200,7 +200,7 @@ Puppet::Type.newtype(:websphere_shared_library) do
     end
   end
 
-  newparam(:node) do
+  newparam(:node_name) do
     isnamevar
     desc 'The name of the node to create this application server on'
   end

--- a/lib/puppet/type/websphere_shared_library.rb
+++ b/lib/puppet/type/websphere_shared_library.rb
@@ -92,7 +92,7 @@ Puppet::Type.newtype(:websphere_shared_library) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:server:CELL_01:AppNode01:AppServer01:PuppetTest
       [
-        %r{^([^:]+):([^:]+):(server):([^:]+):([^:]+):([^:]+)$},
+        %r{^([^:]+):([^:]+):(server):([^:]+):([^:]+):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],

--- a/lib/puppet/type/websphere_variable.rb
+++ b/lib/puppet/type/websphere_variable.rb
@@ -33,7 +33,7 @@ Puppet::Type.newtype(:websphere_variable) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:varName
       [
-        %r{^(.*):(.*)$},
+        %r{^([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:variable],
@@ -41,7 +41,7 @@ Puppet::Type.newtype(:websphere_variable) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:varName
       [
-        %r{^(.*):(.*):(.*)$},
+        %r{^([^:]+):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],
@@ -50,7 +50,7 @@ Puppet::Type.newtype(:websphere_variable) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:cell:CELL_01:varName
       [
-        %r{^(.*):(.*):(cell):(.*):(.*)$},
+        %r{^([^:]+):([^:]+):(cell):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],
@@ -61,7 +61,7 @@ Puppet::Type.newtype(:websphere_variable) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:cluster:CELL_01:TEST_CLUSTER_01:varName
       [
-        %r{^(.*):(.*):(cluster):(.*):(.*):(.*)$},
+        %r{^([^:]+):([^:]+):(cluster):([^:]+):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],
@@ -73,7 +73,7 @@ Puppet::Type.newtype(:websphere_variable) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:node:CELL_01:AppNode01:varName
       [
-        %r{^(.*):(.*):(node):(.*):(.*):(.*)$},
+        %r{^([^:]+):([^:]+):(node):([^:]+):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],
@@ -85,7 +85,7 @@ Puppet::Type.newtype(:websphere_variable) do
       ],
       # /opt/IBM/WebSphere/AppServer/profiles:PROFILE_DMGR_01:server:CELL_01:AppNode01:AppServer01:varName
       [
-        %r{^(.*):(.*):(server):(.*):(.*):(.*)$},
+        %r{^([^:]+):([^:]+):(server):([^:]+):([^:]+):([^:]+):([^:]+)$},
         [
           [:profile_base],
           [:dmgr_profile],
@@ -103,7 +103,7 @@ Puppet::Type.newtype(:websphere_variable) do
     raise ArgumentError, "Invalid scope #{self[:scope]}: Must be cell, cluster, node, or server" unless %r{^(cell|cluster|node|server)$}.match?(self[:scope])
     raise ArgumentError, 'server is required when scope is server' if self[:server].nil? && self[:scope] == 'server'
     raise ArgumentError, 'cell is required' if self[:cell].nil?
-    raise ArgumentError, 'node is required when scope is server, cell, or node' if self[:node_name].nil? && self[:scope] =~ %r{(server|cell|node)}
+    raise ArgumentError, 'node is required when scope is server, or node' if self[:node_name].nil? && self[:scope] =~ %r{(server|node)}
     raise ArgumentError, 'cluster is required when scope is cluster' if self[:cluster].nil? && self[:scope] =~ %r{^cluster$}
     raise ArgumentError, "Invalid profile_base #{self[:profile_base]}" unless Pathname.new(self[:profile_base]).absolute?
 


### PR DESCRIPTION
This fixes the following problems in the following types:

- `namespace_bindings` type: remove `:` from the list of valid characters in the composite namevars
- `namespace_bindings` type: fix missing matching group for the `server` composite namevar option
- `shared_library` type: remove `:` from the list of valid characters in the composite namevars
- `shared_library` type: remove `:` fix missing matching group for the `server` composite namevar option
- `shared_library` type: remove `:` fix inconsistently named variable from `node` to `node_name`
- `websphere_variable` type: remove `:` from the list of valid characters in the composite namevars
- `websphere_variable` type: remove `:` fix missing matching group for the `server` composite namevar option
- `websphere_variable` type: remove `cell` from the list of requirements when scope is `node`